### PR TITLE
IMP añadir selección de compresión

### DIFF
--- a/mesures/a5d.py
+++ b/mesures/a5d.py
@@ -100,6 +100,7 @@ class A5D():
         """
         file_path = os.path.join('/tmp', self.filename)
         self.file.to_csv(
-            file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n'
+            file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',
+            compression=self.default_compression
         )
         return file_path

--- a/mesures/a5d.py
+++ b/mesures/a5d.py
@@ -5,13 +5,19 @@ from mesures.headers import A5D_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
 
 class A5D():
-    def __init__(self, data, distributor=None, comer=None):
+    def __init__(self, data, distributor=None, comer=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param comer: str comer REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'A5D'
-        self.default_compression = 'bz2'
+        self.default_compression = compression
         self.version = 0
         self.distributor = distributor
         self.comer = comer
@@ -36,11 +42,17 @@ class A5D():
 
     @property
     def filename(self):
-        return "{prefix}_{distributor}_{comer}_{timestamp}.{version}.{compression}".format(
-            prefix=self.prefix, distributor=self.distributor, comer=self.comer,
-            timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version,
-            compression=self.default_compression
-        )
+        if self.default_compression:
+            return "{prefix}_{distributor}_{comer}_{timestamp}.{version}.{compression}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version,
+                compression=self.default_compression
+            )
+        else:
+            return "{prefix}_{distributor}_{comer}_{timestamp}.{version}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+            )
 
     @property
     def total(self):
@@ -88,7 +100,6 @@ class A5D():
         """
         file_path = os.path.join('/tmp', self.filename)
         self.file.to_csv(
-            file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',
-            compression=self.default_compression
+            file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n'
         )
         return file_path

--- a/mesures/agrecl.py
+++ b/mesures/agrecl.py
@@ -8,6 +8,11 @@ from mesures.parsers.dummy_data import DummyKeys
 
 class AGRECL(object):
     def __init__(self, data, distributor=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         data = DummyKeys(data).data
         self.file = self.reader(data)
         self.generation_date = datetime.now()

--- a/mesures/agrecl.py
+++ b/mesures/agrecl.py
@@ -7,13 +7,13 @@ from mesures.parsers.dummy_data import DummyKeys
 
 
 class AGRECL(object):
-    def __init__(self, data, distributor=None):
+    def __init__(self, data, distributor=None, compression='bz2'):
         data = DummyKeys(data).data
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'AGRECL'
         self.version = 0
-        self.default_compression = 'bz2'
+        self.default_compression = compression
         self.distributor = distributor
 
     def __repr__(self):
@@ -30,10 +30,16 @@ class AGRECL(object):
 
     @property
     def filename(self):
-        return "{prefix}_{distributor}_{timestamp}.{version}".format(
-            prefix=self.prefix, distributor=self.distributor,
-            timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
-        )
+        if self.default_compression:
+            return "{prefix}_{distributor}_{timestamp}.{version}.{compression}".format(
+                prefix=self.prefix, distributor=self.distributor, timestamp=self.generation_date.strftime('%Y%m%d'),
+                version=self.version, compression=self.default_compression
+            )
+        else:
+            return "{prefix}_{distributor}_{timestamp}.{version}".format(
+                prefix=self.prefix, distributor=self.distributor, timestamp=self.generation_date.strftime('%Y%m%d'),
+                version=self.version
+            )
 
     @property
     def number_of_ups(self):
@@ -68,7 +74,7 @@ class AGRECL(object):
         """
         :return: file path of generated AGRECL File
         """
-        file_path = os.path.join('/tmp', self.filename) + '.' + self.default_compression
+        file_path = os.path.join('/tmp', self.filename)
         self.file.to_csv(
             file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',
             compression=self.default_compression

--- a/mesures/almacenacau.py
+++ b/mesures/almacenacau.py
@@ -7,13 +7,13 @@ from mesures.dates.date import REE_END_DATE
 from mesures.parsers.dummy_data import DummyKeys
 
 class ALMACENACAU(object):
-    def __init__(self, data, distributor=None):
+    def __init__(self, data, distributor=None, compression='bz2'):
         data = DummyKeys(data).data
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'ALMACENACAU'
         self.version = 0
-        self.default_compression = 'bz2'
+        self.default_compression = compression
         self.distributor = distributor
 
     def __repr__(self):
@@ -30,10 +30,17 @@ class ALMACENACAU(object):
 
     @property
     def filename(self):
-        return "{prefix}_{distributor}_{timestamp}.{version}".format(
-            prefix=self.prefix, distributor=self.distributor,
-            timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
-    )
+        if self.default_compression:
+            return "{prefix}_{distributor}_{timestamp}.{version}.{compression}".format(
+                prefix=self.prefix, distributor=self.distributor,
+                timestamp=self.generation_date.strftime('%Y%m%d'),
+                version=self.version, compression=self.default_compression
+            )
+        else:
+            return "{prefix}_{distributor}_{timestamp}.{version}".format(
+                prefix=self.prefix, distributor=self.distributor,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+            )
 
     def reader(self, file_path):
         if isinstance(file_path, str):
@@ -60,7 +67,7 @@ class ALMACENACAU(object):
         """
         :return: file path of generated ALMACENACAU File
         """
-        file_path = os.path.join('/tmp', self.filename) + '.' + self.default_compression
+        file_path = os.path.join('/tmp', self.filename)
         self.file.to_csv(
             file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',
             compression=self.default_compression

--- a/mesures/almacenacau.py
+++ b/mesures/almacenacau.py
@@ -8,6 +8,11 @@ from mesures.parsers.dummy_data import DummyKeys
 
 class ALMACENACAU(object):
     def __init__(self, data, distributor=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         data = DummyKeys(data).data
         self.file = self.reader(data)
         self.generation_date = datetime.now()

--- a/mesures/autoconsumo.py
+++ b/mesures/autoconsumo.py
@@ -8,6 +8,11 @@ from mesures.parsers.dummy_data import DummyKeys
 
 class AUTOCONSUMO(object):
     def __init__(self, data, distributor=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         data = DummyKeys(data).data
         self.file = self.reader(data)
         self.generation_date = datetime.now()

--- a/mesures/autoconsumo.py
+++ b/mesures/autoconsumo.py
@@ -7,13 +7,13 @@ from mesures.dates.date import REE_END_DATE
 from mesures.parsers.dummy_data import DummyKeys
 
 class AUTOCONSUMO(object):
-    def __init__(self, data, distributor=None):
+    def __init__(self, data, distributor=None, compression='bz2'):
         data = DummyKeys(data).data
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'AUTOCONSUMO'
         self.version = 0
-        self.default_compression = 'bz2'
+        self.default_compression = compression
         self.distributor = distributor
 
     def __repr__(self):
@@ -30,10 +30,17 @@ class AUTOCONSUMO(object):
 
     @property
     def filename(self):
-        return "{prefix}_{distributor}_{timestamp}.{version}".format(
-            prefix=self.prefix, distributor=self.distributor,
-            timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
-        )
+        if self.default_compression:
+            return "{prefix}_{distributor}_{timestamp}.{version}.{compression}".format(
+                prefix=self.prefix, distributor=self.distributor,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version,
+                compression=self.default_compression
+            )
+        else:
+            return "{prefix}_{distributor}_{timestamp}.{version}".format(
+                prefix=self.prefix, distributor=self.distributor,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+            )
 
     @property
     def caus(self):
@@ -70,7 +77,7 @@ class AUTOCONSUMO(object):
         """
         :return: file path of generated AUTOCONSUMO File
         """
-        file_path = os.path.join('/tmp', self.filename) + '.' + self.default_compression
+        file_path = os.path.join('/tmp', self.filename)
         self.file.to_csv(
             file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',
             compression=self.default_compression

--- a/mesures/b5d.py
+++ b/mesures/b5d.py
@@ -7,9 +7,9 @@ from mesures.parsers.dummy_data import DummyCurve
 class B5D():
     def __init__(self, data, distributor=None, comer=None, compression='bz2'):
         """
-        :param data:
-        :param distributor:
-        :param comer:
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param comer: str comer REE code
         :param compression: 'bz2', 'gz'... OR False otherwise
         """
         if isinstance(data, list):

--- a/mesures/b5d.py
+++ b/mesures/b5d.py
@@ -101,6 +101,7 @@ class B5D():
         """
         file_path = os.path.join('/tmp', self.filename)
         self.file.to_csv(
-            file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n'
+            file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',
+            compression=self.default_compression
         )
         return file_path

--- a/mesures/b5d.py
+++ b/mesures/b5d.py
@@ -5,13 +5,19 @@ from mesures.headers import B5D_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
 
 class B5D():
-    def __init__(self, data, distributor=None, comer=None):
+    def __init__(self, data, distributor=None, comer=None, compression='bz2'):
+        """
+        :param data:
+        :param distributor:
+        :param comer:
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'B5D'
-        self.default_compression = 'bz2'
+        self.default_compression = compression
         self.version = 0
         self.distributor = distributor
         self.comer = comer
@@ -36,11 +42,17 @@ class B5D():
 
     @property
     def filename(self):
-        return "{prefix}_{distributor}_{comer}_{timestamp}.{version}.{compression}".format(
-            prefix=self.prefix, distributor=self.distributor, comer=self.comer,
-            timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version,
-            compression=self.default_compression
-        )
+        if self.default_compression:
+            return "{prefix}_{distributor}_{comer}_{timestamp}.{version}.{compression}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version,
+                compression=self.default_compression
+            )
+        else:
+            return "{prefix}_{distributor}_{comer}_{timestamp}.{version}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+            )
 
     @property
     def total(self):
@@ -89,7 +101,6 @@ class B5D():
         """
         file_path = os.path.join('/tmp', self.filename)
         self.file.to_csv(
-            file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',
-            compression=self.default_compression
+            file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n'
         )
         return file_path

--- a/mesures/cilcau.py
+++ b/mesures/cilcau.py
@@ -7,6 +7,11 @@ from mesures.cupscau import CUPSCAU
 
 class CILCAU(CUPSCAU):
     def __init__(self, data, distributor=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         super(CILCAU, self).__init__(data, distributor, compression)
         self.prefix = 'CILCAU'
 

--- a/mesures/cilcau.py
+++ b/mesures/cilcau.py
@@ -6,8 +6,8 @@ from mesures.dates.date import REE_END_DATE
 from mesures.cupscau import CUPSCAU
 
 class CILCAU(CUPSCAU):
-    def __init__(self, data, distributor=None):
-        super(CILCAU, self).__init__(data, distributor)
+    def __init__(self, data, distributor=None, compression='bz2'):
+        super(CILCAU, self).__init__(data, distributor, compression)
         self.prefix = 'CILCAU'
 
     @property
@@ -41,7 +41,7 @@ class CILCAU(CUPSCAU):
         """
         :return: file path of generated CUPSCAU File
         """
-        file_path = os.path.join('/tmp', self.filename) + '.' + self.default_compression
+        file_path = os.path.join('/tmp', self.filename)
         self.file.to_csv(
             file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',
             compression=self.default_compression

--- a/mesures/cupscau.py
+++ b/mesures/cupscau.py
@@ -7,13 +7,13 @@ from mesures.dates.date import REE_END_DATE
 from mesures.parsers.dummy_data import DummyKeys
 
 class CUPSCAU(object):
-    def __init__(self, data, distributor=None):
+    def __init__(self, data, distributor=None, compression='bz2'):
         data = DummyKeys(data).data
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'CUPSCAU'
         self.version = 0
-        self.default_compression = 'bz2'
+        self.default_compression = compression
         self.distributor = distributor
 
     def __repr__(self):
@@ -30,10 +30,16 @@ class CUPSCAU(object):
 
     @property
     def filename(self):
-        return "{prefix}_{distributor}_{timestamp}.{version}".format(
-            prefix=self.prefix, distributor=self.distributor,
-            timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
-        )
+        if self.default_compression:
+            return "{prefix}_{distributor}_{timestamp}.{version}.{compression}".format(
+                prefix=self.prefix, distributor=self.distributor, timestamp=self.generation_date.strftime('%Y%m%d'),
+                version=self.version, compression=self.default_compression
+            )
+        else:
+            return "{prefix}_{distributor}_{timestamp}.{version}".format(
+                prefix=self.prefix, distributor=self.distributor,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+            )
 
     @property
     def cups(self):
@@ -74,7 +80,7 @@ class CUPSCAU(object):
         """
         :return: file path of generated CUPSCAU File
         """
-        file_path = os.path.join('/tmp', self.filename) + '.' + self.default_compression
+        file_path = os.path.join('/tmp', self.filename)
         self.file.to_csv(
             file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',
             compression=self.default_compression

--- a/mesures/cupscau.py
+++ b/mesures/cupscau.py
@@ -8,6 +8,11 @@ from mesures.parsers.dummy_data import DummyKeys
 
 class CUPSCAU(object):
     def __init__(self, data, distributor=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         data = DummyKeys(data).data
         self.file = self.reader(data)
         self.generation_date = datetime.now()

--- a/mesures/f1.py
+++ b/mesures/f1.py
@@ -50,7 +50,7 @@ class F1(object):
 
     @property
     def zip_filename(self):
-        return "{prefix}_{distributor}_{measures_date}_{timestamp}".format(
+        return "{prefix}_{distributor}_{measures_date}_{timestamp}.zip".format(
             prefix=self.prefix, distributor=self.distributor, measures_date=self.measures_date.strftime('%Y%m%d'),
             timestamp=self.generation_date.strftime('%Y%m%d')
         )

--- a/mesures/f1.py
+++ b/mesures/f1.py
@@ -6,7 +6,7 @@ from mesures.headers import F1_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
 
 class F1(object):
-    def __init__(self, data, distributor=None):
+    def __init__(self, data, distributor=None, compression='bz2'):
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
         self.file = self.reader(data)
@@ -14,7 +14,7 @@ class F1(object):
         self.prefix = 'F1'
         self.version = 0
         self.distributor = distributor
-        self.default_compression = 'bz2'
+        self.default_compression = compression
 
     def __repr__(self):
         return "{}: {} kWh".format(self.filename, self.total)
@@ -36,9 +36,23 @@ class F1(object):
 
     @property
     def filename(self):
-        return "{prefix}_{distributor}_{measures_date}_{timestamp}.{version}".format(
+        if self.default_compression:
+            return "{prefix}_{distributor}_{measures_date}_{timestamp}.{version}.{compression}".format(
+                prefix=self.prefix, distributor=self.distributor, measures_date=self.measures_date.strftime('%Y%m%d'),
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version,
+                compression=self.default_compression
+            )
+        else:
+            return "{prefix}_{distributor}_{measures_date}_{timestamp}.{version}".format(
+                prefix=self.prefix, distributor=self.distributor, measures_date=self.measures_date.strftime('%Y%m%d'),
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+            )
+
+    @property
+    def zip_filename(self):
+        return "{prefix}_{distributor}_{measures_date}_{timestamp}".format(
             prefix=self.prefix, distributor=self.distributor, measures_date=self.measures_date.strftime('%Y%m%d'),
-            timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+            timestamp=self.generation_date.strftime('%Y%m%d')
         )
 
     @property
@@ -117,16 +131,17 @@ class F1(object):
         daymin = self.file['timestamp'].min()
         daymax = self.file['timestamp'].max()
         self.measures_date = daymin
-        zipped_file = ZipFile(os.path.join('/tmp', self.filename + '.zip'), 'w')
+        zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin
             df = daymin + timedelta(days=1)
             self.measures_date = di
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             dataf['timestamp'] = dataf['timestamp'].apply(lambda x: x.strftime('%Y/%m/%d %H:%M:%S'))
-            filepath = os.path.join('/tmp', self.filename) + '.' + self.default_compression
+            filepath = os.path.join('/tmp', self.filename)
             dataf.to_csv(
-                filepath, sep=';', header=False, columns=columns, index=False, line_terminator=';\n'
+                filepath, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',
+                compression=self.default_compression
             )
             daymin = df
             zipped_file.write(filepath, arcname=os.path.basename(filepath))

--- a/mesures/f1.py
+++ b/mesures/f1.py
@@ -7,6 +7,11 @@ from mesures.parsers.dummy_data import DummyCurve
 
 class F1(object):
     def __init__(self, data, distributor=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
         self.file = self.reader(data)

--- a/mesures/f5.py
+++ b/mesures/f5.py
@@ -22,6 +22,12 @@ DTYPES = {'cups': 'category',
 
 class F5(object):
     def __init__(self, data, distributor=None, comer=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param comer: str comer REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
         self.file = self.reader(data)

--- a/mesures/f5.py
+++ b/mesures/f5.py
@@ -21,13 +21,13 @@ DTYPES = {'cups': 'category',
 
 
 class F5(object):
-    def __init__(self, data, distributor=None, comer=None):
+    def __init__(self, data, distributor=None, comer=None, compression='bz2'):
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'F5'
-        self.default_compression = 'bz2'
+        self.default_compression = compression
         self.version = 0
         self.distributor = distributor
         self.comer = comer
@@ -52,9 +52,24 @@ class F5(object):
 
     @property
     def filename(self):
-        return "{prefix}_{distributor}_{comer}_{measures_date}_{timestamp}.{version}".format(
-            prefix=self.prefix, distributor=self.distributor, comer=self.comer, measures_date=self.measures_date.strftime('%Y%m%d'),
-            timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+        if self.default_compression:
+            return "{prefix}_{distributor}_{comer}_{measures_date}_{timestamp}.{version}.{compression}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                measures_date=self.measures_date.strftime('%Y%m%d'), timestamp=self.generation_date.strftime('%Y%m%d'),
+                version=self.version, compression=self.default_compression
+            )
+        else:
+            return "{prefix}_{distributor}_{comer}_{measures_date}_{timestamp}.{version}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                measures_date=self.measures_date.strftime('%Y%m%d'), timestamp=self.generation_date.strftime('%Y%m%d'),
+                version=self.version
+            )
+
+    @property
+    def zip_filename(self):
+        return "{prefix}_{distributor}_{comer}_{measures_date}_{timestamp}.zip".format(
+            prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+            measures_date=self.measures_date.strftime('%Y%m%d'), timestamp=self.generation_date.strftime('%Y%m%d')
         )
 
     @property
@@ -128,16 +143,17 @@ class F5(object):
         daymax = self.file['timestamp'].max()
         self.measures_date = daymin
         #todo: get a zip filename without measures_date
-        zipped_file = ZipFile(os.path.join('/tmp', self.filename + '.zip'), 'w')
+        zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin
             df = daymin + timedelta(days=1)
             self.measures_date = di
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             dataf['timestamp'] = dataf['timestamp'].apply(lambda x: x.strftime('%Y/%m/%d %H:%M'))
-            filepath = os.path.join('/tmp', self.filename) + '.' + self.default_compression
+            filepath = os.path.join('/tmp', self.filename)
             dataf.to_csv(
-                filepath, sep=';', header=False, columns=columns, index=False, line_terminator=';\n'
+                filepath, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',
+                compression=self.default_compression
             )
             daymin = df
             zipped_file.write(filepath, arcname=os.path.basename(filepath))

--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -8,6 +8,12 @@ import pandas as pd
 
 class F5D(F5):
     def __init__(self, data, distributor=None, comer=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param comer: str comer REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         super(F5D, self).__init__(data, distributor, comer)
         self.prefix = 'F5D'
         self.default_compression = compression

--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -7,17 +7,24 @@ import pandas as pd
 
 
 class F5D(F5):
-    def __init__(self, data, distributor=None, comer=None):
+    def __init__(self, data, distributor=None, comer=None, compression='bz2'):
         super(F5D, self).__init__(data, distributor, comer)
         self.prefix = 'F5D'
-        self.default_compression = 'bz2'
+        self.default_compression = compression
 
     @property
     def filename(self):
-        return "{prefix}_{distributor}_{comer}_{timestamp}.{version}".format(
-            prefix=self.prefix, distributor=self.distributor, comer=self.comer,
-            timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
-        )
+        if self.default_compression:
+            return "{prefix}_{distributor}_{comer}_{timestamp}.{version}.{compression}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version,
+                compression=self.default_compression
+            )
+        else:
+            return "{prefix}_{distributor}_{comer}_{timestamp}.{version}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+            )
 
     def cut_by_dates(self, di, df):
         """
@@ -42,7 +49,7 @@ class F5D(F5):
         F5D contains a hourly invoiced curve
         :return: file path
         """
-        file_path = os.path.join('/tmp', self.filename) + '.' + self.default_compression
+        file_path = os.path.join('/tmp', self.filename)
         self.file.to_csv(
             file_path, sep=';', header=False, columns=COLUMNS, index=False, line_terminator=';\n',
             compression=self.default_compression

--- a/mesures/p1.py
+++ b/mesures/p1.py
@@ -6,7 +6,7 @@ from mesures.headers import P1_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
 
 class P1(object):
-    def __init__(self, data, distributor=None):
+    def __init__(self, data, distributor=None, compression='bz2'):
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
         self.file = self.reader(data)
@@ -14,7 +14,7 @@ class P1(object):
         self.prefix = 'P1'
         self.version = 0
         self.distributor = distributor
-        self.default_compression = 'bz2'
+        self.default_compression = compression
 
     def __repr__(self):
         return "{}: {} kWh".format(self.filename, self.total)
@@ -50,7 +50,7 @@ class P1(object):
 
     @property
     def zip_filename(self):
-        return "{prefix}_{distributor}_{measures_date}_{timestamp}.{version}.zip'".format(
+        return "{prefix}_{distributor}_{measures_date}_{timestamp}.{version}.zip".format(
             prefix=self.prefix, distributor=self.distributor, measures_date=self.measures_date.strftime('%Y%m%d'),
             timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
         )
@@ -128,10 +128,10 @@ class P1(object):
             self.measures_date = di
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             dataf['timestamp'] = dataf['timestamp'].apply(lambda x: x.strftime('%Y/%m/%d %H:%M:%S'))
-            # filepath = os.path.join('/tmp', self.filename) + '.' + self.default_compression
             filepath = os.path.join('/tmp', self.filename)
             dataf.to_csv(
-                filepath, sep=';', header=False, columns=columns, index=False, line_terminator=';\n'
+                filepath, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',
+                compression=self.default_compression
             )
             daymin = df
             zipped_file.write(filepath, arcname=os.path.basename(filepath))

--- a/mesures/p1.py
+++ b/mesures/p1.py
@@ -36,7 +36,21 @@ class P1(object):
 
     @property
     def filename(self):
-        return "{prefix}_{distributor}_{measures_date}_{timestamp}.{version}".format(
+        if self.default_compression:
+            return "{prefix}_{distributor}_{measures_date}_{timestamp}.{version}.{compression}".format(
+                prefix=self.prefix, distributor=self.distributor, measures_date=self.measures_date.strftime('%Y%m%d'),
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version,
+                compression=self.default_compression
+            )
+        else:
+            return "{prefix}_{distributor}_{measures_date}_{timestamp}.{version}".format(
+                prefix=self.prefix, distributor=self.distributor, measures_date=self.measures_date.strftime('%Y%m%d'),
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+            )
+
+    @property
+    def zip_filename(self):
+        return "{prefix}_{distributor}_{measures_date}_{timestamp}.{version}.zip'".format(
             prefix=self.prefix, distributor=self.distributor, measures_date=self.measures_date.strftime('%Y%m%d'),
             timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
         )
@@ -107,7 +121,7 @@ class P1(object):
         daymin = self.file['timestamp'].min()
         daymax = self.file['timestamp'].max()
         self.measures_date = daymin
-        zipped_file = ZipFile(os.path.join('/tmp', self.filename + '.zip'), 'w')
+        zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin
             df = daymin + timedelta(days=1)

--- a/mesures/p1.py
+++ b/mesures/p1.py
@@ -7,6 +7,11 @@ from mesures.parsers.dummy_data import DummyCurve
 
 class P1(object):
     def __init__(self, data, distributor=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
         self.file = self.reader(data)

--- a/mesures/p1.py
+++ b/mesures/p1.py
@@ -50,9 +50,9 @@ class P1(object):
 
     @property
     def zip_filename(self):
-        return "{prefix}_{distributor}_{measures_date}_{timestamp}.{version}.zip".format(
+        return "{prefix}_{distributor}_{measures_date}_{timestamp}.zip".format(
             prefix=self.prefix, distributor=self.distributor, measures_date=self.measures_date.strftime('%Y%m%d'),
-            timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+            timestamp=self.generation_date.strftime('%Y%m%d')
         )
 
     @property

--- a/mesures/p1.py
+++ b/mesures/p1.py
@@ -114,7 +114,8 @@ class P1(object):
             self.measures_date = di
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             dataf['timestamp'] = dataf['timestamp'].apply(lambda x: x.strftime('%Y/%m/%d %H:%M:%S'))
-            filepath = os.path.join('/tmp', self.filename) + '.' + self.default_compression
+            # filepath = os.path.join('/tmp', self.filename) + '.' + self.default_compression
+            filepath = os.path.join('/tmp', self.filename)
             dataf.to_csv(
                 filepath, sep=';', header=False, columns=columns, index=False, line_terminator=';\n'
             )

--- a/mesures/p1d.py
+++ b/mesures/p1d.py
@@ -3,25 +3,31 @@ from mesures.p1 import P1
 from mesures.headers import P1_HEADER as columns
 
 class P1D(P1):
-    def __init__(self, data, distributor=None, comer=None):
-        super(P1D, self).__init__(data, distributor)
+    def __init__(self, data, distributor=None, comer=None, compression='bz2'):
+        super(P1D, self).__init__(data, distributor, compression)
         self.prefix = 'P1D'
-        self.default_compression = 'bz2'
         self.comer = comer
 
     @property
     def filename(self):
-        return "{prefix}_{distributor}_{comer}_{timestamp}.{version}".format(
-            prefix=self.prefix, distributor=self.distributor, comer=self.comer,
-            timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
-        )
+        if self.default_compression:
+            return "{prefix}_{distributor}_{comer}_{timestamp}.{version}.{compression}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version,
+                compression=self.default_compression
+            )
+        else:
+            return "{prefix}_{distributor}_{comer}_{timestamp}.{version}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+            )
 
     def writer(self):
         """
         P1D contains all curve measure in one file
         :return: file path
         """
-        file_path = os.path.join('/tmp', self.filename) + '.' + self.default_compression
+        file_path = os.path.join('/tmp', self.filename)
         self.file['timestamp'] = self.file['timestamp'].apply(lambda x: x.strftime('%Y/%m/%d %H:%M:%S'))
         self.file.to_csv(
             file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',

--- a/mesures/p1d.py
+++ b/mesures/p1d.py
@@ -4,6 +4,12 @@ from mesures.headers import P1_HEADER as columns
 
 class P1D(P1):
     def __init__(self, data, distributor=None, comer=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param comer: str comer REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         super(P1D, self).__init__(data, distributor, compression)
         self.prefix = 'P1D'
         self.comer = comer

--- a/mesures/p2.py
+++ b/mesures/p2.py
@@ -4,6 +4,11 @@ from mesures.headers import P2_HEADER as columns
 
 class P2(P1):
     def __init__(self, data, distributor=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         super(P2, self).__init__(data, distributor, compression)
         self.prefix = 'P2'
 

--- a/mesures/p2.py
+++ b/mesures/p2.py
@@ -3,8 +3,8 @@ from mesures.p1 import P1
 from mesures.headers import P2_HEADER as columns
 
 class P2(P1):
-    def __init__(self, data, distributor=None):
-        super(P2, self).__init__(data, distributor)
+    def __init__(self, data, distributor=None, compression='bz2'):
+        super(P2, self).__init__(data, distributor, compression)
         self.prefix = 'P2'
 
     def reader(self, filepath):

--- a/mesures/p2d.py
+++ b/mesures/p2d.py
@@ -5,6 +5,12 @@ from mesures.headers import P2_HEADER as columns
 
 class P2D(P2):
     def __init__(self, data, distributor=None, comer=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param comer: str comer REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         super(P2D, self).__init__(data, distributor)
         self.prefix = 'P2D'
         self.default_compression = compression

--- a/mesures/p2d.py
+++ b/mesures/p2d.py
@@ -4,25 +4,32 @@ from mesures.p2 import P2
 from mesures.headers import P2_HEADER as columns
 
 class P2D(P2):
-    def __init__(self, data, distributor=None, comer=None):
+    def __init__(self, data, distributor=None, comer=None, compression='bz2'):
         super(P2D, self).__init__(data, distributor)
         self.prefix = 'P2D'
-        self.default_compression = 'bz2'
+        self.default_compression = compression
         self.comer = comer
 
     @property
     def filename(self):
-        return "{prefix}_{distributor}_{comer}_{timestamp}.{version}".format(
-            prefix=self.prefix, distributor=self.distributor, comer=self.comer,
-            timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
-        )
+        if self.default_compression:
+            return "{prefix}_{distributor}_{comer}_{timestamp}.{version}.{compression}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version,
+                compression=self.default_compression
+            )
+        else:
+            return "{prefix}_{distributor}_{comer}_{timestamp}.{version}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+            )
 
     def writer(self):
         """
         P2D contains all curve measure in one file
         :return: file path
         """
-        file_path = os.path.join('/tmp', self.filename) + '.' + self.default_compression
+        file_path = os.path.join('/tmp', self.filename)
         self.file['timestamp'] = self.file['timestamp'].apply(lambda x: x.strftime('%Y/%m/%d %H:%M:%S'))
         self.file.to_csv(
             file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',

--- a/mesures/p5d.py
+++ b/mesures/p5d.py
@@ -5,13 +5,13 @@ from mesures.headers import P5D_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
 
 class P5D(object):
-    def __init__(self, data, distributor=None, comer=None):
+    def __init__(self, data, distributor=None, comer=None, compression='bz2'):
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'P5D'
-        self.default_compression = 'bz2'
+        self.default_compression = compression
         self.version = 0
         self.distributor = distributor
         self.comer = comer
@@ -36,10 +36,17 @@ class P5D(object):
 
     @property
     def filename(self):
-        return "{prefix}_{distributor}_{comer}_{timestamp}.{version}".format(
-            prefix=self.prefix, distributor=self.distributor, comer=self.comer,
-            timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
-        )
+        if self.default_compression:
+            return "{prefix}_{distributor}_{comer}_{timestamp}.{version}.{compression}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version,
+                compression=self.default_compression
+            )
+        else:
+            return "{prefix}_{distributor}_{comer}_{timestamp}.{version}".format(
+                prefix=self.prefix, distributor=self.distributor, comer=self.comer,
+                timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
+            )
 
     @property
     def total(self):
@@ -85,7 +92,7 @@ class P5D(object):
         P5D contains a hourly raw curve
         :return: file path
         """
-        file_path = os.path.join('/tmp', self.filename) + '.' + self.default_compression
+        file_path = os.path.join('/tmp', self.filename)
         self.file.to_csv(
             file_path, sep=';', header=False, columns=columns, index=False, line_terminator=';\n',
             compression=self.default_compression

--- a/mesures/p5d.py
+++ b/mesures/p5d.py
@@ -6,6 +6,12 @@ from mesures.parsers.dummy_data import DummyCurve
 
 class P5D(object):
     def __init__(self, data, distributor=None, comer=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param comer: str comer REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
         self.file = self.reader(data)

--- a/mesures/parsers/dummy_data.py
+++ b/mesures/parsers/dummy_data.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from six import string_types
 
 
 class DummyCurve(object):
@@ -32,7 +33,7 @@ class DummyCurve(object):
                 # Active input and output
                 data['ai'] = data.pop('ai')
                 data['ae'] = data.pop('ao')
-            if 'season' in data and (isinstance(data['season'], str) or isinstance(data['season'], unicode)):
+            if 'season' in data and isinstance(data['season'], string_types):
                 try:
                     data['season'] = int(data['season'])
                 except ValueError:

--- a/mesures/pmest.py
+++ b/mesures/pmest.py
@@ -7,6 +7,11 @@ from mesures.parsers.dummy_data import DummyCurve
 
 class PMEST(object):
     def __init__(self, data, distributor=None, compression='bz2'):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
         self.file = self.reader(data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ expects
 pandas==0.23.4
 mamba<0.11.0
 numpy
+six

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -12,6 +12,7 @@ from mesures.agrecl import AGRECL
 from mesures.almacenacau import ALMACENACAU
 from mesures.autoconsumo import AUTOCONSUMO
 from mesures.cupscau import CUPSCAU
+from mesures.cilcau import CILCAU
 from random import randint
 try:
     from StringIO import StringIO
@@ -194,6 +195,16 @@ with description('An CUPSCAU'):
             {'cau': 'A', 'cups': '1', 'tipus_consum': '12345', 'data_alta': '2021-01-12', 'comentari': 'E0'}
         ]
         f = CUPSCAU(data, compression=False)
+        assert f.filename.endswith('.0')
+        filepath = f.writer()
+        assert 'bz2' not in filepath
+
+with description('An CILCAU'):
+    with it('with compression=False must be a raw file'):
+        data = [
+            {'cau': 'A', 'cil': '1', 'data_alta': '2021-01-12', 'comentari': 'E0'}
+        ]
+        f = CILCAU(data, compression=False)
         assert f.filename.endswith('.0')
         filepath = f.writer()
         assert 'bz2' not in filepath

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -9,6 +9,7 @@ from mesures.p1d import P1D
 from mesures.a5d import A5D
 from mesures.b5d import B5D
 from mesures.agrecl import AGRECL
+from mesures.almacenacau import ALMACENACAU
 from random import randint
 try:
     from StringIO import StringIO
@@ -149,7 +150,7 @@ with description('An F1'):
         assert isinstance(f.number_of_cups, int)
 
 
-with description('A AGRECL'):
+with description('An AGRECL'):
     with it('with compression=False must be a raw file'):
         data = [
             {'origen': 'A', 'tipus_operacio': '', 'distribuidora': '12345', 'comercialitzadora': '1111',
@@ -157,6 +158,17 @@ with description('A AGRECL'):
              'data_alta': '2021-01-12'}
         ]
         f = AGRECL(data, compression=False)
+        assert f.filename.endswith('.0')
+        filepath = f.writer()
+        assert 'bz2' not in filepath
+
+with description('An ALMACENACAU'):
+    with fit('with compression=False must be a raw file'):
+        data = [
+            {'cau': 'A', 'potencia_nominal': '1', 'energia_emmagatzemable': '12345', 'tecnologia_emmagatzematge': '1111',
+             'data_alta': '2021-01-12', 'comentari': 'E0'}
+        ]
+        f = ALMACENACAU(data, compression=False)
         assert f.filename.endswith('.0')
         filepath = f.writer()
         assert 'bz2' not in filepath

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -11,6 +11,7 @@ from mesures.b5d import B5D
 from mesures.agrecl import AGRECL
 from mesures.almacenacau import ALMACENACAU
 from mesures.autoconsumo import AUTOCONSUMO
+from mesures.cupscau import CUPSCAU
 from random import randint
 try:
     from StringIO import StringIO
@@ -183,6 +184,16 @@ with description('An AUTOCONSUMO'):
              'data_alta': '2021-01-12'}
         ]
         f = AUTOCONSUMO(data, compression=False)
+        assert f.filename.endswith('.0')
+        filepath = f.writer()
+        assert 'bz2' not in filepath
+
+with description('An CUPSCAU'):
+    with it('with compression=False must be a raw file'):
+        data = [
+            {'cau': 'A', 'cups': '1', 'tipus_consum': '12345', 'data_alta': '2021-01-12', 'comentari': 'E0'}
+        ]
+        f = CUPSCAU(data, compression=False)
         assert f.filename.endswith('.0')
         filepath = f.writer()
         assert 'bz2' not in filepath

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -200,7 +200,7 @@ with description('An CUPSCAU'):
         assert 'bz2' not in filepath
 
 with description('An CILCAU'):
-    with it('with compression=False must be a raw file'):
+    with fit('with compression=False must be a raw file'):
         data = [
             {'cau': 'A', 'cil': '1', 'data_alta': '2021-01-12', 'comentari': 'E0'}
         ]

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -16,6 +16,7 @@ except ImportError:
 import base64
 import bz2
 import numpy as np
+import zipfile
 
 
 class SampleData:
@@ -154,31 +155,44 @@ with description('A P1'):
         f = P1(data)
         assert isinstance(f, P1)
 
-    with it('bz2 as a default compression'):
-        # mirar com ho fa a sobre, fer un P1 i provar les funcions:
-        # filename (ha de portar el compression si es marca)
-        # writer() i mirar que no porti bz2
+    with it('is a zip file'):
         data = SampleData().get_sample_data()
-        f = P1(data)
-        f1 = f.writer()
+        f = P1(data, distributor='9999')
+        filepath = f.writer()
+        assert zipfile.is_zipfile(filepath)
+        assert f.zip_filename.endswith('.zip')
+
+    with it('with bz2 activated, must be a daily bz2 file in a zip'):
+        data = SampleData().get_sample_data()
+        f = P1(data, distributor='1234', compression='bz2')
+        filepath = f.writer()
         assert isinstance(f.filename, str)
         assert '.bz2' in f.filename
         assert f.filename.endswith('.bz2')
-        assert isinstance(f1, str)
-        assert '.bz2' not in f1
+        assert isinstance(filepath, str)
+        assert '.bz2' not in filepath
 
-with description('An P1D'):
+        # Decompress ppal zip file and decompress bz2 files
+        zip_file = zipfile.ZipFile(filepath, "r")
+        for name in zip_file.namelist():
+            assert name.endswith('.bz2')
+            file_bz2 = bz2.decompress(zip_file.read(name))
+
+with description('A P1D'):
     with it('instance of P1D Class'):
         data = SampleData().get_sample_data()
         f = P1D(data)
         assert isinstance(f, P1D)
 
-        with it('bz2 as a default compression'):
-            data = SampleData().get_sample_data()
-            f = P1D(data)
-            f.writer()
-            assert isinstance((f.filename, str))
-            assert '.bz2'
+    with it('bz2 as a default compression'):
+        data = SampleData().get_sample_data()
+        f = P1D(data)
+        assert isinstance(f.filename, str)
+        assert '.bz2' in f.filename
+        assert f.filename.endswith('.bz2')
+        f1 = f.writer()
+        assert isinstance(f1, str)
+        assert '.bz2' in f1
 
 with description('An A5D'):
     with it('bz2 as a default compression'):
@@ -195,6 +209,7 @@ with description('An A5D'):
         assert '.bz2' not in f.filename
         assert f.filename.endswith('.0')
         f1 = f.writer()
+        assert isinstance(f1, str)
         assert 'bz2' not in f1
         assert f1.endswith('.0')
 
@@ -206,6 +221,7 @@ with description('A B5D'):
         assert '.bz2' in f.filename
         assert f.filename.endswith('.bz2')
         f1 = f.writer()
+        assert isinstance(f1, str)
         assert f1.endswith('.bz2')
 
     with it('a raw file'):
@@ -214,6 +230,7 @@ with description('A B5D'):
         assert '.bz2' not in f.filename
         assert f.filename.endswith('.0')
         f1 = f.writer()
+        assert isinstance(f1, str)
         assert 'bz2' not in f1
         assert f1.endswith('.0')
 

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -10,6 +10,7 @@ from mesures.a5d import A5D
 from mesures.b5d import B5D
 from mesures.agrecl import AGRECL
 from mesures.almacenacau import ALMACENACAU
+from mesures.autoconsumo import AUTOCONSUMO
 from random import randint
 try:
     from StringIO import StringIO
@@ -163,12 +164,25 @@ with description('An AGRECL'):
         assert 'bz2' not in filepath
 
 with description('An ALMACENACAU'):
-    with fit('with compression=False must be a raw file'):
+    with it('with compression=False must be a raw file'):
         data = [
             {'cau': 'A', 'potencia_nominal': '1', 'energia_emmagatzemable': '12345', 'tecnologia_emmagatzematge': '1111',
              'data_alta': '2021-01-12', 'comentari': 'E0'}
         ]
         f = ALMACENACAU(data, compression=False)
+        assert f.filename.endswith('.0')
+        filepath = f.writer()
+        assert 'bz2' not in filepath
+
+with description('An AUTOCONSUMO'):
+    with it('with compression=False must be a raw file'):
+        data = [
+            {'cau': 'A', 'miteco': '1', 'reg_auto_prov': '12345', 'reg_auto_def': '1111',
+             'tipus_autoconsum': 'A', 'tipus_antiabocament': '1', 'nom': 'test', 'configuracio_mesura': '1111',
+             'potencia_nominal': '2', 'codi_postal': '17007', 'subgrup': '12345', 'emmagatzematge': '1111',
+             'data_alta': '2021-01-12'}
+        ]
+        f = AUTOCONSUMO(data, compression=False)
         assert f.filename.endswith('.0')
         filepath = f.writer()
         assert 'bz2' not in filepath

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -8,6 +8,7 @@ from mesures.p1 import P1
 from mesures.p1d import P1D
 from mesures.a5d import A5D
 from mesures.b5d import B5D
+from mesures.agrecl import AGRECL
 from random import randint
 try:
     from StringIO import StringIO
@@ -136,7 +137,6 @@ with description('An F1'):
         data = SampleData().get_sample_data()
         f = F1(data)
         res = f.writer()
-        import zipfile
         assert zipfile.is_zipfile(res)
 
     with it('has its class methods'):
@@ -148,6 +148,18 @@ with description('An F1'):
         assert isinstance(f.cups, list)
         assert isinstance(f.number_of_cups, int)
 
+
+with description('A AGRECL'):
+    with it('with compression=False must be a raw file'):
+        data = [
+            {'origen': 'A', 'tipus_operacio': '', 'distribuidora': '12345', 'comercialitzadora': '1111',
+             'tensio': 'E0', 'tarifa': '2T', 'dh': 'E3', 'tipo': '5', 'provincia': 'GI', 'tipus_demanda': '0',
+             'data_alta': '2021-01-12'}
+        ]
+        f = AGRECL(data, compression=False)
+        assert f.filename.endswith('.0')
+        filepath = f.writer()
+        assert 'bz2' not in filepath
 
 with description('A P1'):
     with it('instance of P1 Class'):

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -200,7 +200,7 @@ with description('An CUPSCAU'):
         assert 'bz2' not in filepath
 
 with description('An CILCAU'):
-    with fit('with compression=False must be a raw file'):
+    with it('with compression=False must be a raw file'):
         data = [
             {'cau': 'A', 'cil': '1', 'data_alta': '2021-01-12', 'comentari': 'E0'}
         ]

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -206,7 +206,8 @@ with description('A B5D'):
         assert isinstance(f.filename, str)
         assert '.bz2' in f.filename
         assert f.filename.endswith('.bz2')
-        f.writer()
+        f1 = f.writer()
+        assert f1.endswith('.bz2')
 
     with it('a raw file'):
         f = B5D([{'cups': 'XDS', 'timestamp': datetime.now(), 'season': 1, 'ai': 0, 'factura': 123}], compression=False)
@@ -214,5 +215,5 @@ with description('A B5D'):
         assert '.bz2' not in f.filename
         assert f.filename.endswith('.0')
         f1 = f.writer()
+        assert f1.endswith('.0')
 
-        # provar el writer() que passa si el compression es igual a False

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -18,7 +18,6 @@ import bz2
 import numpy as np
 
 
-
 class SampleData:
     @staticmethod
     def get_sample_data():
@@ -161,17 +160,12 @@ with description('A P1'):
         # writer() i mirar que no porti bz2
         data = SampleData().get_sample_data()
         f = P1(data)
-        f.writer()
+        f1 = f.writer()
         assert isinstance(f.filename, str)
         assert '.bz2' in f.filename
         assert f.filename.endswith('.bz2')
-
-    with it('writes a bz2 compressed file'):
-        data = SampleData().get_sample_data()
-        f = P1(data)
-        f1 = f.writer()
         assert isinstance(f1, str)
-        assert '.bz2' in f1
+        assert '.bz2' not in f1
 
 with description('An P1D'):
     with it('instance of P1D Class'):
@@ -192,12 +186,17 @@ with description('An A5D'):
         assert isinstance(f.filename, str)
         assert '.bz2' in f.filename
         assert f.filename.endswith('.bz2')
+        f1 = f.writer()
+        assert f1.endswith('.bz2')
 
     with it('a raw file'):
         f = A5D([{'cups': 'XDS', 'timestamp': datetime.now(), 'season': 1, 'ai': 0, 'factura': 123}], compression=False)
         assert isinstance(f.filename, str)
         assert '.bz2' not in f.filename
         assert f.filename.endswith('.0')
+        f1 = f.writer()
+        assert 'bz2' not in f1
+        assert f1.endswith('.0')
 
 with description('A B5D'):
     with it('bz2 as a default compression'):
@@ -215,5 +214,6 @@ with description('A B5D'):
         assert '.bz2' not in f.filename
         assert f.filename.endswith('.0')
         f1 = f.writer()
+        assert 'bz2' not in f1
         assert f1.endswith('.0')
 

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -6,6 +6,8 @@ from mesures.f1 import F1
 from mesures.f5d import F5D
 from mesures.p1 import P1
 from mesures.p1d import P1D
+from mesures.a5d import A5D
+from mesures.b5d import B5D
 from random import randint
 try:
     from StringIO import StringIO
@@ -147,14 +149,70 @@ with description('An F1'):
         assert isinstance(f.number_of_cups, int)
 
 
-with description('An P1'):
+with description('A P1'):
     with it('instance of P1 Class'):
         data = SampleData().get_sample_data()
         f = P1(data)
         assert isinstance(f, P1)
+
+    with it('bz2 as a default compression'):
+        # mirar com ho fa a sobre, fer un P1 i provar les funcions:
+        # filename (ha de portar el compression si es marca)
+        # writer() i mirar que no porti bz2
+        data = SampleData().get_sample_data()
+        f = P1(data)
+        f.writer()
+        assert isinstance(f.filename, str)
+        assert '.bz2' in f.filename
+        assert f.filename.endswith('.bz2')
+
+    with it('writes a bz2 compressed file'):
+        data = SampleData().get_sample_data()
+        f = P1(data)
+        f1 = f.writer()
+        assert isinstance(f1, str)
+        assert '.bz2' in f1
 
 with description('An P1D'):
     with it('instance of P1D Class'):
         data = SampleData().get_sample_data()
         f = P1D(data)
         assert isinstance(f, P1D)
+
+        with it('bz2 as a default compression'):
+            data = SampleData().get_sample_data()
+            f = P1D(data)
+            f.writer()
+            assert isinstance((f.filename, str))
+            assert '.bz2'
+
+with description('An A5D'):
+    with it('bz2 as a default compression'):
+        f = A5D([{'cups': 'XDS', 'timestamp': datetime.now(), 'season': 1, 'ai': 0, 'factura': 123}], compression='bz2')
+        assert isinstance(f.filename, str)
+        assert '.bz2' in f.filename
+        assert f.filename.endswith('.bz2')
+
+    with it('a raw file'):
+        f = A5D([{'cups': 'XDS', 'timestamp': datetime.now(), 'season': 1, 'ai': 0, 'factura': 123}], compression=False)
+        assert isinstance(f.filename, str)
+        assert '.bz2' not in f.filename
+        assert f.filename.endswith('.0')
+
+with description('A B5D'):
+    with it('bz2 as a default compression'):
+        f = B5D([{'cups': 'XDS', 'timestamp': datetime.now(), 'season': 1, 'ai': 0, 'factura': 123}],
+                distributor='1234', comer='1235', compression='bz2')
+        assert isinstance(f.filename, str)
+        assert '.bz2' in f.filename
+        assert f.filename.endswith('.bz2')
+        f.writer()
+
+    with it('a raw file'):
+        f = B5D([{'cups': 'XDS', 'timestamp': datetime.now(), 'season': 1, 'ai': 0, 'factura': 123}], compression=False)
+        assert isinstance(f.filename, str)
+        assert '.bz2' not in f.filename
+        assert f.filename.endswith('.0')
+        f1 = f.writer()
+
+        # provar el writer() que passa si el compression es igual a False


### PR DESCRIPTION
Añadir posibilidad de comprimir o no un fichero. Anteriormente solo comprimía en BZ2

- todo: Añadir `isinstance(s, string_types)` como https://stackoverflow.com/questions/11301138/how-to-check-if-variable-is-string-with-python-2-and-3-compatibility para mantener compatibilidad a la hora de revisar: https://github.com/gisce/mesures/blob/fe516cf05b293be9b75605707c5d34a55e1f86f4/mesures/parsers/dummy_data.py#L35
- todo: Añadir al `requirements.txt` la librería `six`: https://github.com/gisce/mesures/blob/fe516cf05b293be9b75605707c5d34a55e1f86f4/requirements.txt#L4