### PR TITLE
Correcciones en la generación del fichero ALMACENACAU

### DIFF
--- a/mesures/almacenacau.py
+++ b/mesures/almacenacau.py
@@ -61,7 +61,6 @@ class ALMACENACAU(object):
             lambda x: REE_END_DATE if not isinstance(x, pd.Timestamp) else x.strftime('%Y%m%d'))
         df['data_alta'] = df['data_alta'].apply(lambda x: x.strftime('%Y%m%d'))
         df['tecnologia_emmagatzematge'] = df['tecnologia_emmagatzematge'].astype(str)
-        df['tecnologia_emmagatzematge'] = df['tecnologia_emmagatzematge'].apply(lambda x: x.zfill(2))
         try:
             df['comentari'] = np.where(df['comentari'], df['comentari'], '')
         except KeyError:


### PR DESCRIPTION
- En el fichero `Ficheros para el intercambio de información de medida`, se establece que la tecnología de almacenamiento se informa con dos carácteres.

![Captura de pantalla de 2022-04-27 10-27-02](https://user-images.githubusercontent.com/49635897/165475574-724d5533-7a54-4bb6-b1cc-2c1f956dcc1b.png)

- Por contra, en el fichero `Tratamiento de datos estructurales y de medidas de instalaciones de autoconsumo` se contradice esta información estableciendo los códigos de la tecnología en formato de un único carácter.

![Captura de pantalla de 2022-04-27 10-24-08](https://user-images.githubusercontent.com/49635897/165475465-1f521cd7-d1e3-4aa6-9b42-584a830873e5.png)

- Tras enviar ficheros `ALMACENACAU` al Concentrador Secundario, se ha visto que se procesan correctamente si se informa la tecnología con los códigos de un único carácter en lugar de dos.