### PR TITLE
Soporte para versionado

### DIFF
--- a/mesures/a5d.py
+++ b/mesures/a5d.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 
 class A5D():
-    def __init__(self, data, distributor=None, comer=None, compression='bz2'):
+    def __init__(self, data, distributor=None, comer=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -20,7 +20,7 @@ class A5D():
         self.generation_date = datetime.now()
         self.prefix = 'A5D'
         self.default_compression = compression
-        self.version = 0
+        self.version = version
         self.distributor = distributor
         self.comer = comer
 

--- a/mesures/agrecl.py
+++ b/mesures/agrecl.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 
 class AGRECL(object):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -17,7 +17,7 @@ class AGRECL(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'AGRECL'
-        self.version = 0
+        self.version = version
         self.default_compression = compression
         self.distributor = distributor
 

--- a/mesures/almacenacau.py
+++ b/mesures/almacenacau.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 class ALMACENACAU(object):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -18,7 +18,7 @@ class ALMACENACAU(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'ALMACENACAU'
-        self.version = 0
+        self.version = version
         self.default_compression = compression
         self.distributor = distributor
 

--- a/mesures/autoconsumo.py
+++ b/mesures/autoconsumo.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 class AUTOCONSUMO(object):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -18,7 +18,7 @@ class AUTOCONSUMO(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'AUTOCONSUMO'
-        self.version = 0
+        self.version = version
         self.default_compression = compression
         self.distributor = distributor
 

--- a/mesures/b5d.py
+++ b/mesures/b5d.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 
 class B5D():
-    def __init__(self, data, distributor=None, comer=None, compression='bz2'):
+    def __init__(self, data, distributor=None, comer=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -20,7 +20,7 @@ class B5D():
         self.generation_date = datetime.now()
         self.prefix = 'B5D'
         self.default_compression = compression
-        self.version = 0
+        self.version = version
         self.distributor = distributor
         self.comer = comer
 

--- a/mesures/cilcau.py
+++ b/mesures/cilcau.py
@@ -8,13 +8,13 @@ import pandas as pd
 
 
 class CILCAU(CUPSCAU):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
         :param compression: 'bz2', 'gz'... OR False otherwise
         """
-        super(CILCAU, self).__init__(data, distributor, compression)
+        super(CILCAU, self).__init__(data, distributor, compression, version=version)
         self.prefix = 'CILCAU'
 
     @property

--- a/mesures/cildat.py
+++ b/mesures/cildat.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 
 class CILDAT(object):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -17,7 +17,7 @@ class CILDAT(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'CILDAT'
-        self.version = 0
+        self.version = version
         self.default_compression = compression
         self.distributor = distributor
         self.columns = COLUMNS

--- a/mesures/cumpelectro.py
+++ b/mesures/cumpelectro.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 class CUMPELECTRO(object):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -19,7 +19,7 @@ class CUMPELECTRO(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'CUMPELECTRO'
-        self.version = 0
+        self.version = version
         self.distributor = distributor
         self.default_compression = compression
 

--- a/mesures/cups45.py
+++ b/mesures/cups45.py
@@ -4,11 +4,12 @@ from mesures.cupsdat import CUPSDAT
 
 
 class CUPS45(CUPSDAT):
-    def __init__(self, data, distributor=None, compression='bz2', columns=COLUMNS):
+    def __init__(self, data, distributor=None, compression='bz2', columns=COLUMNS, version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
         :param compression: 'bz2', 'gz'... OR False otherwise
         """
-        super(CUPS45, self).__init__(data, distributor=distributor, compression=compression, columns=columns)
+        super(CUPS45, self).__init__(data, distributor=distributor, compression=compression,
+                                     columns=columns, version=version)
         self.prefix = 'CUPS45'

--- a/mesures/cupscau.py
+++ b/mesures/cupscau.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 class CUPSCAU(object):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -18,7 +18,7 @@ class CUPSCAU(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'CUPSCAU'
-        self.version = 0
+        self.version = version
         self.default_compression = compression
         self.distributor = distributor
 

--- a/mesures/cupsdat.py
+++ b/mesures/cupsdat.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 
 class CUPSDAT(object):
-    def __init__(self, data, distributor=None, compression='bz2', columns=COLUMNS):
+    def __init__(self, data, distributor=None, compression='bz2', columns=COLUMNS, version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -18,7 +18,7 @@ class CUPSDAT(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'CUPSDAT'
-        self.version = 0
+        self.version = version
         self.default_compression = compression
         self.distributor = distributor
 

--- a/mesures/cupselectro.py
+++ b/mesures/cupselectro.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 class CUPSELECTRO(object):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -19,7 +19,7 @@ class CUPSELECTRO(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'CUPSELECTRO'
-        self.version = 0
+        self.version = version
         self.distributor = distributor
         self.default_compression = compression
 

--- a/mesures/enelectroaut.py
+++ b/mesures/enelectroaut.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 class ENELECTROAUT(object):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -19,7 +19,7 @@ class ENELECTROAUT(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'ENELECTROAUT'
-        self.version = 0
+        self.version = version
         self.distributor = distributor
         self.default_compression = compression
 

--- a/mesures/f1.py
+++ b/mesures/f1.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 class F1(object):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -20,7 +20,7 @@ class F1(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'F1'
-        self.version = 0
+        self.version = version
         self.distributor = distributor
         self.default_compression = compression
 

--- a/mesures/f3.py
+++ b/mesures/f3.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 class F3(object):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -19,7 +19,7 @@ class F3(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'F3'
-        self.version = 0
+        self.version = version
         self.distributor = distributor
         self.default_compression = compression
 

--- a/mesures/f5.py
+++ b/mesures/f5.py
@@ -20,7 +20,7 @@ DTYPES = {'cups': 'category',
 
 
 class F5(object):
-    def __init__(self, data, distributor=None, comer=None, compression='bz2', columns=COLUMNS, dtypes=DTYPES):
+    def __init__(self, data, distributor=None, comer=None, compression='bz2', columns=COLUMNS, dtypes=DTYPES, version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -35,7 +35,7 @@ class F5(object):
         self.generation_date = datetime.now()
         self.prefix = 'F5'
         self.default_compression = compression
-        self.version = 0
+        self.version = version
         self.distributor = distributor
         self.comer = comer
 

--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -10,7 +10,7 @@ TYPES.update({'factura': 'category'})
 
 
 class F5D(F5):
-    def __init__(self, data, distributor=None, comer=None, compression='bz2', columns=COLUMNS, dtypes=TYPES):
+    def __init__(self, data, distributor=None, comer=None, compression='bz2', columns=COLUMNS, dtypes=TYPES, version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -18,7 +18,7 @@ class F5D(F5):
         :param compression: 'bz2', 'gz'... OR False otherwise
         """
         super(F5D, self).__init__(data, distributor=distributor, comer=comer, compression=compression,
-                                  columns=columns, dtypes=dtypes)
+                                  columns=columns, dtypes=dtypes, version=version)
         self.prefix = 'F5D'
 
     @property

--- a/mesures/mcil345.py
+++ b/mesures/mcil345.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 class MCIL345(object):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -19,7 +19,7 @@ class MCIL345(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'MCIL345'
-        self.version = 0
+        self.version = version
         self.distributor = distributor
         self.default_compression = compression
         self.measures_date = None

--- a/mesures/mcil345.py
+++ b/mesures/mcil345.py
@@ -59,11 +59,12 @@ class MCIL345(object):
 
     @property
     def zip_filename(self):
-        return "{prefix}_{distributor}_{measures_date}_{timestamp}.zip".format(
+        return "{prefix}_{distributor}_{measures_date}_{timestamp}.{version}.zip".format(
             prefix=self.prefix,
             distributor=self.distributor,
             measures_date=self.measures_date[:10].replace('/', ''),
-            timestamp=self.generation_date.strftime('%Y%m%d')
+            timestamp=self.generation_date.strftime('%Y%m%d'),
+            version=self.version
         )
 
     @property
@@ -155,6 +156,12 @@ class MCIL345(object):
             self.measures_date = di
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             # dataf['timestamp'] = dataf['timestamp'].apply(lambda x: x.strftime(DATETIME_HOUR_MASK))
+
+            existing_files = os.listdir('/tmp')
+            if existing_files:
+                max_version = max([int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f])
+                self.version = max_version + 1
+
             file_path = os.path.join('/tmp', self.filename)
             kwargs = {'sep': ';',
                       'header': False,

--- a/mesures/medidas.py
+++ b/mesures/medidas.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 
 class MEDIDAS(object):
-    def __init__(self, data, period=2, distributor=None, compression='bz2'):
+    def __init__(self, data, period=2, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -18,7 +18,7 @@ class MEDIDAS(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'medidas'
-        self.version = 0
+        self.version = version
         self.period = period
         self.distributor = distributor
         self.default_compression = compression

--- a/mesures/p1.py
+++ b/mesures/p1.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 class P1(object):
-    def __init__(self, data, distributor=None, compression='bz2', columns=COLUMNS):
+    def __init__(self, data, distributor=None, compression='bz2', columns=COLUMNS, version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -20,7 +20,7 @@ class P1(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'P1'
-        self.version = 0
+        self.version = version
         self.distributor = distributor
         self.default_compression = compression
 

--- a/mesures/p1d.py
+++ b/mesures/p1d.py
@@ -5,14 +5,15 @@ from mesures.p1 import P1
 
 
 class P1D(P1):
-    def __init__(self, data, distributor=None, comer=None, compression='bz2', columns=COLUMNS):
+    def __init__(self, data, distributor=None, comer=None, compression='bz2', columns=COLUMNS, version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
         :param comer: str comer REE code
         :param compression: 'bz2', 'gz'... OR False otherwise
         """
-        super(P1D, self).__init__(data, distributor=distributor, compression=compression, columns=columns)
+        super(P1D, self).__init__(data, distributor=distributor, compression=compression,
+                                  columns=columns, version=version)
         self.prefix = 'P1D'
         self.comer = comer
 

--- a/mesures/p2.py
+++ b/mesures/p2.py
@@ -5,13 +5,13 @@ import pandas as pd
 
 
 class P2(P1):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
         :param compression: 'bz2', 'gz'... OR False otherwise
         """
-        super(P2, self).__init__(data, distributor, compression)
+        super(P2, self).__init__(data, distributor, compression, version=version)
         self.prefix = 'P2'
 
     def reader(self, filepath):

--- a/mesures/p2d.py
+++ b/mesures/p2d.py
@@ -5,14 +5,14 @@ import os
 
 
 class P2D(P2):
-    def __init__(self, data, distributor=None, comer=None, compression='bz2'):
+    def __init__(self, data, distributor=None, comer=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
         :param comer: str comer REE code
         :param compression: 'bz2', 'gz'... OR False otherwise
         """
-        super(P2D, self).__init__(data, distributor)
+        super(P2D, self).__init__(data, distributor, version=version)
         self.prefix = 'P2D'
         self.default_compression = compression
         self.comer = comer

--- a/mesures/p5d.py
+++ b/mesures/p5d.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 
 class P5D(object):
-    def __init__(self, data, distributor=None, comer=None, compression='bz2'):
+    def __init__(self, data, distributor=None, comer=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -21,7 +21,7 @@ class P5D(object):
         self.generation_date = datetime.now()
         self.prefix = 'P5D'
         self.default_compression = compression
-        self.version = 0
+        self.version = version
         self.distributor = distributor
         self.comer = comer
 

--- a/mesures/pmest.py
+++ b/mesures/pmest.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 class PMEST(object):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -19,7 +19,7 @@ class PMEST(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'PMEST'
-        self.version = 0
+        self.version = version
         self.distributor = distributor
         self.default_compression = compression
 

--- a/mesures/potelectro.py
+++ b/mesures/potelectro.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 class POTELECTRO(object):
-    def __init__(self, data, distributor=None, compression='bz2'):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -19,7 +19,7 @@ class POTELECTRO(object):
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'POTELECTRO'
-        self.version = 0
+        self.version = version
         self.distributor = distributor
         self.default_compression = compression
 


### PR DESCRIPTION
## Objetivos

- Se ha añadido el soporte para especificar el número de versión en la generación de ficheros (0 por defecto).
- El fichero `MCIL345` versiona los ficheros incluidos en el "zip" que retorna su generación.

## Checklist

- [ ] Test code
