### PR TITLE
Soporte para versionado en los ficheros CUPSDAT y CUPS45

### DIFF
--- a/mesures/cupsdat.py
+++ b/mesures/cupsdat.py
@@ -75,6 +75,11 @@ class CUPSDAT(object):
         """
         :return: file path of generated CUPSDAT File
         """
+        existing_files = os.listdir('/tmp')
+        if existing_files:
+            max_version = max([int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f])
+            self.version = max_version + 1
+
         file_path = os.path.join('/tmp', self.filename)
 
         kwargs = {'sep': ';',

--- a/mesures/cupsdat.py
+++ b/mesures/cupsdat.py
@@ -77,8 +77,9 @@ class CUPSDAT(object):
         """
         existing_files = os.listdir('/tmp')
         if existing_files:
-            max_version = max([int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f])
-            self.version = max_version + 1
+            versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f]
+            if versions:
+                self.version = max(versions) + 1
 
         file_path = os.path.join('/tmp', self.filename)
 

--- a/mesures/mcil345.py
+++ b/mesures/mcil345.py
@@ -159,8 +159,9 @@ class MCIL345(object):
 
             existing_files = os.listdir('/tmp')
             if existing_files:
-                max_version = max([int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f])
-                self.version = max_version + 1
+                versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f]
+                if versions:
+                    self.version = max(versions) + 1
 
             file_path = os.path.join('/tmp', self.filename)
             kwargs = {'sep': ';',


### PR DESCRIPTION
## Objetivos

- Los ficheros `CUPSDAT` y `CUPS45` se versionan automáticamente si en el directorio temporal donde se generan ya existen ficheros del mismo tipo para el mismo periodo.

## Relacionado

From https://github.com/gisce/erp/issues/15388

## Checklist

- [ ] Test code
