### PR TITLE
Correcciones en el formato del fichero P1D

### DIFF
--- a/mesures/p1d.py
+++ b/mesures/p1d.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import P1_HEADER as COLUMNS
 from mesures.p1 import P1
+import os
 
 
 class P1D(P1):
@@ -35,3 +36,20 @@ class P1D(P1):
             comer=self.comer,
             timestamp=self.generation_date.strftime(SIMPLE_DATE_MASK)
         )
+
+    def writer(self):
+        """
+        :return: file path of generated P1D File
+        """
+        file_path = os.path.join('/tmp', self.filename)
+        kwargs = {'sep': ';',
+                  'header': False,
+                  'columns': self.columns,
+                  'index': False,
+                  'line_terminator': ';\n'
+                  }
+        if self.default_compression:
+            kwargs.update({'compression': self.default_compression})
+
+        self.file.to_csv(file_path, **kwargs)
+        return file_path

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -702,7 +702,6 @@ with description('A P1D'):
         assert f.filename.endswith('.bz2')
         f1 = f.writer()
         assert isinstance(f1, str)
-        assert '.zip' in f1
 
 with description('An A5D'):
     with it('bz2 as a default compression'):


### PR DESCRIPTION
## Objetivos

- Corregir el formato de salida del fichero `P1D`.

## Comportamiento antiguo

- El P1D se formatea como fichero ZIP con ficheros diarios en su interior (planos o comprimidos en `.bz2` según se requiera).

## Comportamiento nuevo

- El P1D se formatea como único fichero (plano o comprimido en `.bz2` según se requiera).

## Checklist

- [ ] Test code
