### PR TITLE
Mejoras en la exportación de F5D cuando la información se lee desde fichero temporal

### DIFF
--- a/mesures/f5.py
+++ b/mesures/f5.py
@@ -131,7 +131,8 @@ class F5(object):
             {'ai': 'sum', 'ae': 'sum', 'r1': 'sum', 'r2': 'sum', 'r3': 'sum', 'r4': 'sum'}
         ).reset_index()
 
-        df['timestamp'] = df['timestamp'].apply(lambda x: x.strftime(DATETIME_HOUR_MASK))
+        if isinstance(filepath, list):
+            df['timestamp'] = df['timestamp'].apply(lambda x: x.strftime(DATETIME_HOUR_MASK))
 
         for key in ['ai', 'ae', 'r1', 'r2', 'r3', 'r4']:
             if key not in df:

--- a/mesures/f5.py
+++ b/mesures/f5.py
@@ -118,7 +118,7 @@ class F5(object):
 
     def reader(self, filepath):
         if isinstance(filepath, str):
-            df = pd.read_csv(filepath, sep=';', names=self.columns, dtype=self.dtypes)
+            df = pd.read_csv(filepath, sep=';', names=self.columns + ['res'], dtype=self.dtypes)
         elif isinstance(filepath, list):
             df = pd.DataFrame(data=filepath)
         else:

--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -48,7 +48,7 @@ class F5D(F5):
 
     def reader(self, filepath):
         if isinstance(filepath, str):
-            df = pd.read_csv(filepath, sep=';', names=self.columns, dtype=self.dtypes)
+            df = pd.read_csv(filepath, sep=';', names=self.columns + ['res'], dtype=self.dtypes)
         elif isinstance(filepath, list):
             df = pd.DataFrame(data=filepath)
         else:

--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -64,7 +64,8 @@ class F5D(F5):
             {'ai': 'sum', 'ae': 'sum', 'r1': 'sum', 'r2': 'sum', 'r3': 'sum', 'r4': 'sum'}
         ).reset_index()
 
-        df['timestamp'] = df['timestamp'].apply(lambda x: x.strftime('%Y/%m/%d %H:%M'))
+        if isinstance(filepath, list):
+            df['timestamp'] = df['timestamp'].apply(lambda x: x.strftime('%Y/%m/%d %H:%M'))
 
         for key in ['ai', 'ae', 'r1', 'r2', 'r3', 'r4']:
             if key not in df:


### PR DESCRIPTION
## Objetivos

- Si el contenido se lee desde una ruta y no desde una lista de diccionarios, se añade una columna extra para el delimitador de línea final (`;`), así el orden y la asociación de las columnas se mantienen en el DataFrame.

## Checklist

- [ ] Test code
