### PR TITLE
Evitar generar ficheros diarios MCIL345 sin contenido

### DIFF
--- a/mesures/mcil345.py
+++ b/mesures/mcil345.py
@@ -156,25 +156,26 @@ class MCIL345(object):
             self.measures_date = di
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             # dataf['timestamp'] = dataf['timestamp'].apply(lambda x: x.strftime(DATETIME_HOUR_MASK))
+            # Avoid to generate file if dataframe is empty
+            if len(dataf):
+                existing_files = os.listdir('/tmp')
+                if existing_files:
+                    versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f]
+                    if versions:
+                        self.version = max(versions) + 1
 
-            existing_files = os.listdir('/tmp')
-            if existing_files:
-                versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f]
-                if versions:
-                    self.version = max(versions) + 1
+                file_path = os.path.join('/tmp', self.filename)
+                kwargs = {'sep': ';',
+                          'header': False,
+                          'columns': self.columns,
+                          'index': False,
+                          'line_terminator': ';\n'
+                          }
+                if self.default_compression:
+                    kwargs.update({'compression': self.default_compression})
+                dataf.to_csv(file_path, **kwargs)
+                zipped_file.write(file_path, arcname=os.path.basename(file_path))
 
-            file_path = os.path.join('/tmp', self.filename)
-            kwargs = {'sep': ';',
-                      'header': False,
-                      'columns': self.columns,
-                      'index': False,
-                      'line_terminator': ';\n'
-                      }
-            if self.default_compression:
-                kwargs.update({'compression': self.default_compression})
-
-            dataf.to_csv(file_path, **kwargs)
             daymin = df
-            zipped_file.write(file_path, arcname=os.path.basename(file_path))
         zipped_file.close()
         return zipped_file.filename


### PR DESCRIPTION
## Objetivos

- Cuando se trocea una curva `MCIL345` en ficheros diarios, estos no se deben generar si su contenido queda hueco.

## Checklist

- [ ] Test code
