### PR TITLE
Correcciones en la generación de ficheros AUTOCONSUMO

### DIFF
--- a/mesures/autoconsumo.py
+++ b/mesures/autoconsumo.py
@@ -66,8 +66,6 @@ class AUTOCONSUMO(object):
         else:
             raise Exception("Filepath must be an str or a list")
 
-        for key in ('reg_auto_prov', 'reg_auto_def', 'miteco'):
-            df[key] = ''
         df['data_baixa'] = df['data_baixa'].apply(
             lambda x: REE_END_DATE if not isinstance(x, pd.Timestamp) else x.strftime('%Y%m%d'))
         df['data_alta'] = df['data_alta'].apply(lambda x: x.strftime('%Y%m%d'))


### PR DESCRIPTION
## Objetivos

- No dejar vacíos los campos que informan de los números de registro MITECO, provisional y definitivo.

## Comportamiento antiguo

- Los campos se dejan vacíos.

## Comportamiento nuevo

- Los campos se llenan con la información de los autoconsumos.

## Relacionado

- Closes #https://github.com/gisce/erp/issues/16340

## Checklist

- [ ] Test code
