### PR TITLE
Se ha añadido una propiedad para contar las horar por CIL en el fichero MEDIDAS

### DIFF
--- a/mesures/medidas.py
+++ b/mesures/medidas.py
@@ -97,6 +97,10 @@ class MEDIDAS(object):
         return list(set(self.file['cil']))
 
     @property
+    def hours_per_cil(self):
+        return self.file['cil'].value_counts().reset_index().to_dict('records')
+
+    @property
     def number_of_cils(self):
         return len(list(set(self.file['cil'])))
 

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -853,6 +853,7 @@ with description('A MEDIDAS'):
         res = f.writer()
         assert isinstance(f.cils, list)
         assert isinstance(f.number_of_cils, int)
+        assert isinstance(f.hours_per_cil, list)
         assert isinstance(f.ae, int)
         assert isinstance(f.r2, int)
         assert isinstance(f.r3, int)


### PR DESCRIPTION
## Objetivos

- La propiedad `hours_per_cil` retorna una lista de diccionarios con el recuento de horas para cada CIL presente en el fichero generado.

## Relacionado

- Improves #47

## Checklist

- [x] Test code
