### PR TITLE
Permitir generar el fichero MEDIDAS agrupando los CIL por Unidad de Programación

### DIFF
--- a/mesures/a5d.py
+++ b/mesures/a5d.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import A5D_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 import os
 import pandas as pd
 
@@ -106,7 +107,7 @@ class A5D():
                   'header': False,
                   'columns': columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/agrecl.py
+++ b/mesures/agrecl.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import AGRECL_HEADER as columns
 from mesures.parsers.dummy_data import DummyKeys
+from mesures.utils import check_line_terminator_param
 import os
 import pandas as pd
 
@@ -80,7 +81,7 @@ class AGRECL(object):
                   'header': False,
                   'columns': columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/almacenacau.py
+++ b/mesures/almacenacau.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import ALMACENACAU_HEADER as columns
 from mesures.parsers.dummy_data import DummyKeys
+from mesures.utils import check_line_terminator_param
 import os
 import numpy as np
 import pandas as pd
@@ -77,7 +78,7 @@ class ALMACENACAU(object):
                   'header': False,
                   'columns': columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/autoconsumo.py
+++ b/mesures/autoconsumo.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import AUTOCONSUMO_HEADER as columns
 from mesures.parsers.dummy_data import DummyKeys
+from mesures.utils import check_line_terminator_param
 import os
 import numpy as np
 import pandas as pd
@@ -86,7 +87,7 @@ class AUTOCONSUMO(object):
                   'header': False,
                   'columns': columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/b5d.py
+++ b/mesures/b5d.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import B5D_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 import os
 import pandas as pd
 
@@ -106,7 +107,7 @@ class B5D():
                   'header': False,
                   'columns': columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/cilcau.py
+++ b/mesures/cilcau.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.cupscau import CUPSCAU
 from mesures.headers import CILCAU_HEADER as columns
+from mesures.utils import check_line_terminator_param
 import os
 import numpy as np
 import pandas as pd
@@ -53,7 +54,7 @@ class CILCAU(CUPSCAU):
                   'header': False,
                   'columns': columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/cildat.py
+++ b/mesures/cildat.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import CILDAT_HEADER as COLUMNS
 from mesures.parsers.dummy_data import DummyKeys
+from mesures.utils import check_line_terminator_param
 import os
 import pandas as pd
 
@@ -81,7 +82,7 @@ class CILDAT(object):
                   'header': False,
                   'columns': COLUMNS,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
 
         if self.default_compression:

--- a/mesures/cumpelectro.py
+++ b/mesures/cumpelectro.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import CUMPELECTRO_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 from zipfile import ZipFile
 import os
 import pandas as pd
@@ -80,7 +81,7 @@ class CUMPELECTRO(object):
                   'header': False,
                   'columns': columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/cupscau.py
+++ b/mesures/cupscau.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import CUPSCAU_HEADER as columns
 from mesures.parsers.dummy_data import DummyKeys
+from mesures.utils import check_line_terminator_param
 import os
 import numpy as np
 import pandas as pd
@@ -91,7 +92,7 @@ class CUPSCAU(object):
                   'header': False,
                   'columns': columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/cupsdat.py
+++ b/mesures/cupsdat.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import CUPSDAT_HEADER as COLUMNS
 from mesures.parsers.dummy_data import DummyKeys
+from mesures.utils import check_line_terminator_param
 import os
 import pandas as pd
 
@@ -87,7 +88,7 @@ class CUPSDAT(object):
                   'header': False,
                   'columns': self.columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
 
         if self.default_compression:

--- a/mesures/cupselectro.py
+++ b/mesures/cupselectro.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import CUPSELECTRO_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 from zipfile import ZipFile
 import os
 import pandas as pd
@@ -84,7 +85,7 @@ class CUPSELECTRO(object):
                   'header': False,
                   'columns': columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/enelectroaut.py
+++ b/mesures/enelectroaut.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import ENELECTROAUT_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 from zipfile import ZipFile
 import os
 import pandas as pd
@@ -81,7 +82,7 @@ class ENELECTROAUT(object):
                   'header': False,
                   'columns': columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/f1.py
+++ b/mesures/f1.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import F1_HEADER as COLUMNS
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 from zipfile import ZipFile
 import os
 import pandas as pd
@@ -151,7 +152,7 @@ class F1(object):
                       'header': False,
                       'columns': self.columns,
                       'index': False,
-                      'line_terminator': ';\n'
+                      check_line_terminator_param(): ';\n'
                       }
             if self.default_compression:
                 kwargs.update({'compression': self.default_compression})

--- a/mesures/f3.py
+++ b/mesures/f3.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import F3_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 from zipfile import ZipFile
 import os
 import pandas as pd
@@ -125,7 +126,7 @@ class F3(object):
                       'header': False,
                       'columns': columns,
                       'index': False,
-                      'line_terminator': ';\n'
+                      check_line_terminator_param(): ';\n'
                       }
             if self.default_compression:
                 kwargs.update({'compression': self.default_compression})

--- a/mesures/f5.py
+++ b/mesures/f5.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import F5_HEADER as COLUMNS
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 from zipfile import ZipFile
 import os
 import pandas as pd
@@ -162,7 +163,7 @@ class F5(object):
                       'header': False,
                       'columns': self.columns,
                       'index': False,
-                      'line_terminator': ';\n'
+                      check_line_terminator_param(): ';\n'
                       }
             if self.default_compression:
                 kwargs.update({'compression': self.default_compression})

--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import F5D_HEADER as COLUMNS
 from mesures.f5 import F5, DTYPES
+from mesures.utils import check_line_terminator_param
 import os
 import pandas as pd
 
@@ -83,7 +84,7 @@ class F5D(F5):
                   'header': False,
                   'columns': self.columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/mcil345.py
+++ b/mesures/mcil345.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import MCIL345_HEADER as COLUMNS
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 from zipfile import ZipFile
 import os
 import pandas as pd
@@ -169,7 +170,7 @@ class MCIL345(object):
                           'header': False,
                           'columns': self.columns,
                           'index': False,
-                          'line_terminator': ';\n'
+                          check_line_terminator_param(): ';\n'
                           }
                 if self.default_compression:
                     kwargs.update({'compression': self.default_compression})

--- a/mesures/medidas.py
+++ b/mesures/medidas.py
@@ -20,6 +20,7 @@ class MEDIDAS(object):
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
         self.file_type = file_type
+        self.by_upr = by_upr
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'medidas'
@@ -28,7 +29,6 @@ class MEDIDAS(object):
         self.distributor = distributor
         self.default_compression = compression
         self.columns = columns
-        self.by_upr = by_upr
 
     def __repr__(self):
         return "{}: {} kWh".format(self.filename, self.total)

--- a/mesures/medidas.py
+++ b/mesures/medidas.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import MEDIDAS_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 from zipfile import ZipFile
 import os
 import pandas as pd
@@ -199,7 +200,7 @@ class MEDIDAS(object):
                   'header': False,
                   'columns': self.columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
 
         if self.file_type == 'medidas_cnmc':

--- a/mesures/medidas.py
+++ b/mesures/medidas.py
@@ -8,12 +8,14 @@ import pandas as pd
 
 
 class MEDIDAS(object):
-    def __init__(self, data, period=2, distributor=None, file_type='medidas_cnmc', compression='bz2', version=0):
+    def __init__(self, data, period=2, distributor=None, file_type='medidas_cnmc', compression='bz2', by_upr=False,
+                 version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
         :param file_type: str in ('medidas_cnmc', 'medidas_ree')
         :param compression: 'bz2', 'gz'... OR False otherwise
+        :param by_upr: boolean
         """
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
@@ -26,6 +28,7 @@ class MEDIDAS(object):
         self.distributor = distributor
         self.default_compression = compression
         self.columns = columns
+        self.by_upr = by_upr
 
     def __repr__(self):
         return "{}: {} kWh".format(self.filename, self.total)
@@ -118,10 +121,13 @@ class MEDIDAS(object):
             pass
 
         # Group by CIL and balance energies
+        group_fields = ['cil', 'timestamp', 'season']
+
+        if self.by_upr:
+            group_fields.append('uprs')
+
         df = df.groupby(
-            ['cil',
-             'timestamp',
-             'season']
+            group_fields
         ).agg(
             {'ai': 'sum',
              'ae': 'sum',

--- a/mesures/p1.py
+++ b/mesures/p1.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import P1_HEADER as COLUMNS
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 from zipfile import ZipFile
 import os
 import pandas as pd
@@ -149,7 +150,7 @@ class P1(object):
                           'header': False,
                           'columns': self.columns,
                           'index': False,
-                          'line_terminator': ';\n'
+                          check_line_terminator_param(): ';\n'
                           }
                 if self.default_compression:
                     kwargs.update({'compression': self.default_compression})

--- a/mesures/p1d.py
+++ b/mesures/p1d.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import P1_HEADER as COLUMNS
 from mesures.p1 import P1
+from mesures.utils import check_line_terminator_param
 import os
 
 
@@ -52,7 +53,7 @@ class P1D(P1):
                   'header': False,
                   'columns': self.columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/p2d.py
+++ b/mesures/p2d.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from mesures.headers import P2_HEADER as columns
 from mesures.p2 import P2
+from mesures.utils import check_line_terminator_param
 import os
 
 
@@ -42,7 +43,7 @@ class P2D(P2):
                   'header': False,
                   'columns': columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/p5d.py
+++ b/mesures/p5d.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import P5D_HEADER as COLUMNS
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 import os
 import pandas as pd
 
@@ -100,7 +101,7 @@ class P5D(object):
                   'header': False,
                   'columns': self.columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/pmest.py
+++ b/mesures/pmest.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import PMEST_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 from zipfile import ZipFile
 import os
 import pandas as pd
@@ -142,7 +143,7 @@ class PMEST(object):
                       'header': False,
                       'columns': columns,
                       'index': False,
-                      'line_terminator': ';\n'
+                      check_line_terminator_param(): ';\n'
                       }
             if self.default_compression:
                 kwargs.update({'compression': self.default_compression})

--- a/mesures/potelectro.py
+++ b/mesures/potelectro.py
@@ -2,6 +2,7 @@
 from mesures.dates import *
 from mesures.headers import POTELECTRO_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
+from mesures.utils import check_line_terminator_param
 from zipfile import ZipFile
 import os
 import pandas as pd
@@ -82,7 +83,7 @@ class POTELECTRO(object):
                   'header': False,
                   'columns': columns,
                   'index': False,
-                  'line_terminator': ';\n'
+                  check_line_terminator_param(): ';\n'
                   }
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})

--- a/mesures/utils.py
+++ b/mesures/utils.py
@@ -6,6 +6,8 @@ def check_line_terminator_param():
         params = inspect.getargspec(pd.DataFrame.to_csv).args
     except ValueError:
         params = inspect.getfullargspec(pd.DataFrame.to_csv).args
+    except AttributeError:
+        params = inspect.getfullargspec(pd.DataFrame.to_csv).args
     if 'line_terminator' in params:
         return 'line_terminator'
     else:

--- a/mesures/utils.py
+++ b/mesures/utils.py
@@ -1,0 +1,8 @@
+import inspect
+import pandas as pd
+
+def check_line_terminator_param():
+    if 'line_terminator' in inspect.getargspec(pd.DataFrame.to_csv).args:
+        return 'line_terminator'
+    else:
+        return 'lineterminator'

--- a/mesures/utils.py
+++ b/mesures/utils.py
@@ -2,7 +2,11 @@ import inspect
 import pandas as pd
 
 def check_line_terminator_param():
-    if 'line_terminator' in inspect.getargspec(pd.DataFrame.to_csv).args:
+    try:
+        params = inspect.getargspec(pd.DataFrame.to_csv).args
+    except ValueError:
+        params = inspect.getfullargspec(pd.DataFrame.to_csv).args
+    if 'line_terminator' in params:
         return 'line_terminator'
     else:
         return 'lineterminator'

--- a/mesures/utils.py
+++ b/mesures/utils.py
@@ -2,10 +2,11 @@ import inspect
 import pandas as pd
 
 def check_line_terminator_param():
-    try:
-        params = inspect.getargspec(pd.DataFrame.to_csv).args
-    except ValueError:
-        params = inspect.getfullargspec(pd.DataFrame.to_csv).args
+    # 'line_terminator' is deprecated in pandas
+    # 'getargspec' is deprecated in python3
+    if not hasattr(inspect, 'getargspec'):
+        inspect.getargspec = inspect.getfullargspec
+    params = inspect.getargspec(pd.DataFrame.to_csv).args
     if 'line_terminator' in params:
         return 'line_terminator'
     else:

--- a/mesures/utils.py
+++ b/mesures/utils.py
@@ -2,11 +2,10 @@ import inspect
 import pandas as pd
 
 def check_line_terminator_param():
-    # 'line_terminator' is deprecated in pandas
-    # 'getargspec' is deprecated in python3
-    if not hasattr(inspect, 'getargspec'):
-        inspect.getargspec = inspect.getfullargspec
-    params = inspect.getargspec(pd.DataFrame.to_csv).args
+    try:
+        params = inspect.getargspec(pd.DataFrame.to_csv).args
+    except ValueError:
+        params = inspect.getfullargspec(pd.DataFrame.to_csv).args
     if 'line_terminator' in params:
         return 'line_terminator'
     else:


### PR DESCRIPTION
## Objetivos

- Permitir mediante un parámetro opcional, retornar un fichero ZIP conteniendo un `MEDIDAS` por cada Unidad de Programación (representante) de los CIL cuya curva llega a la generación.
- Se ha creado un fichero de utilidades para mantener la compatibilidad entre versiones de `Python` y de `Pandas`.
