### PR TITLE
Actualizaciones en la generación del fichero AUTOCONSUMO

### DIFF
--- a/mesures/autoconsumo.py
+++ b/mesures/autoconsumo.py
@@ -72,9 +72,7 @@ class AUTOCONSUMO(object):
         df['data_alta'] = df['data_alta'].apply(lambda x: x.strftime('%Y%m%d'))
         df['emmagatzematge'] = np.where(df['emmagatzematge'], 'S', 'N')
         #df['potencia_nominal'] = np.where(df['cil'], '', df['potencia_nominal'])
-        df['subgrup'] = df['subgrup'].apply(lambda x: '{}.{}.{}'.format(
-            x[0], x[1], x[2] if x != '' else ''
-        ))
+        df['subgrup'] = df['subgrup'].apply(lambda x: '{}.{}.{}'.format(x[0], x[1], x[2]) if x != '' else '')
         df['tipus_antiabocament'] = (
             df['tipus_antiabocament'].apply(lambda x: '' if (x == 0 or not x or x == '') else x))
         df = df[columns]

--- a/mesures/autoconsumo.py
+++ b/mesures/autoconsumo.py
@@ -72,9 +72,9 @@ class AUTOCONSUMO(object):
         df['data_alta'] = df['data_alta'].apply(lambda x: x.strftime('%Y%m%d'))
         df['emmagatzematge'] = np.where(df['emmagatzematge'], 'S', 'N')
         #df['potencia_nominal'] = np.where(df['cil'], '', df['potencia_nominal'])
-        df['subgrup'] =np.where(df['subgrup'] != '',
-                                '{}.{}.{}'.format(df['subgrup'][0], df['subgrup'][1], df['subgrup'][2]),
-                                '')
+        df['subgrup'] = df['subgrup'].apply(lambda x: '{}.{}.{}'.format(
+            x[0], x[1], x[2] if x != '' else ''
+        ))
         df['tipus_antiabocament'] = (
             df['tipus_antiabocament'].apply(lambda x: '' if (x == 0 or not x or x == '') else x))
         df = df[columns]

--- a/mesures/autoconsumo.py
+++ b/mesures/autoconsumo.py
@@ -72,7 +72,9 @@ class AUTOCONSUMO(object):
         df['data_alta'] = df['data_alta'].apply(lambda x: x.strftime('%Y%m%d'))
         df['emmagatzematge'] = np.where(df['emmagatzematge'], 'S', 'N')
         #df['potencia_nominal'] = np.where(df['cil'], '', df['potencia_nominal'])
-        df['subgrup'] = df['subgrup'].apply(lambda x: x.replace('.', '')[:2])
+        df['subgrup'] = df['subgrup'].apply(lambda x: '{}.{}.{}'.format(
+            x[0], x[1], x[2]
+        ))
         df['tipus_antiabocament'] = (
             df['tipus_antiabocament'].apply(lambda x: '' if (x == 0 or not x or x == '') else x.zfill(2)))
         df = df[columns]

--- a/mesures/autoconsumo.py
+++ b/mesures/autoconsumo.py
@@ -76,7 +76,7 @@ class AUTOCONSUMO(object):
             x[0], x[1], x[2]
         ))
         df['tipus_antiabocament'] = (
-            df['tipus_antiabocament'].apply(lambda x: '' if (x == 0 or not x or x == '') else x.zfill(2)))
+            df['tipus_antiabocament'].apply(lambda x: '' if (x == 0 or not x or x == '') else x))
         df = df[columns]
         return df
 

--- a/mesures/autoconsumo.py
+++ b/mesures/autoconsumo.py
@@ -72,9 +72,9 @@ class AUTOCONSUMO(object):
         df['data_alta'] = df['data_alta'].apply(lambda x: x.strftime('%Y%m%d'))
         df['emmagatzematge'] = np.where(df['emmagatzematge'], 'S', 'N')
         #df['potencia_nominal'] = np.where(df['cil'], '', df['potencia_nominal'])
-        df['subgrup'] = df['subgrup'].apply(lambda x: '{}.{}.{}'.format(
-            x[0], x[1], x[2]
-        ))
+        df['subgrup'] =np.where(df['subgrup'] != '',
+                                '{}.{}.{}'.format(df['subgrup'][0], df['subgrup'][1], df['subgrup'][2]),
+                                '')
         df['tipus_antiabocament'] = (
             df['tipus_antiabocament'].apply(lambda x: '' if (x == 0 or not x or x == '') else x))
         df = df[columns]

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -624,7 +624,7 @@ with description('An AUTOCONSUMO'):
         data = [
             {'cau': 'A', 'miteco': '1', 'reg_auto_prov': '12345', 'reg_auto_def': '1111',
              'tipus_autoconsum': 'A', 'tipus_antiabocament': '1', 'nom': 'test', 'configuracio_mesura': '1111',
-             'potencia_nominal': '2', 'codi_postal': '17007', 'subgrup': '12345', 'emmagatzematge': '1111',
+             'potencia_nominal': '2', 'codi_postal': '17007', 'subgrup': 'b11', 'emmagatzematge': '1111',
              'data_alta': '2021-01-12'}
         ]
         f = AUTOCONSUMO(data, compression=False)


### PR DESCRIPTION
## Objetivos

- Corregir el formato de comunicación del subgrupo en los ficheros AUTOCONSUMO.
    - Este dato se obtiene de la tecnología del generador asociado a la instalación.
- Corregir el formato de comunicación del sistema de anti-vertido en los ficheros AUTOCONSUMO.
    - Se debe expresar con un único carácter, en vez de con dos.  

## Comportamiento antiguo

- El subgrupo se informa con los dos primeros carácteres y sin puntos.
- El sistema antivertido se informa con dos carácteres.

## Comportamiento nuevo

- El subgrupo se informa completo, con los tres carácteres separados por un punto.
- El sistema antivertido se informa con un carácter.

## Checklist

- [x] Test code

![Captura desde 2023-04-19 11-06-39](https://user-images.githubusercontent.com/49635897/233028420-c0210363-be62-4c58-8e0b-1d0a6b902651.png)
