### PR TITLE
Nuevo fichero de medidas MCIL345QH para RECORE y Autoconsumos

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - `F5`
 - `F5D`
 - `MCIL345`
+- `MCIL345QH`
 - `MEDIDAS`
 - `P1`
 - `P1D`

--- a/mesures/mcil345qh.py
+++ b/mesures/mcil345qh.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+from mesures.dates import *
+from mesures.headers import MCIL345_HEADER as COLUMNS
+from mesures.mcil345 import MCIL345
+from mesures.utils import check_line_terminator_param
+from zipfile import ZipFile
+import os
+import pandas as pd
+
+
+class MCIL345QH(MCIL345):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
+        super(MCIL345QH, self).__init__(data, distributor=distributor, compression=compression, version=version)
+        self.prefix = 'MCIL345QH'
+
+    def reader(self, filepath):
+        if isinstance(filepath, str):
+            df = pd.read_csv(filepath, sep=';', names=COLUMNS)
+        elif isinstance(filepath, list):
+            df = pd.DataFrame(data=filepath)
+        else:
+            raise Exception("Filepath must be an str or a list")
+        try:
+            df['timestamp'] = df.apply(lambda row: row['timestamp'].strftime(DATETIME_HOUR_MASK), axis=1)
+        except Exception as err:
+            # Timestamp is already well parsed
+            pass
+
+        # Group by CIL and balance energies
+        df = df.groupby(
+            ['cil',
+             'timestamp',
+             'season']
+        ).agg(
+            {'ai': 'sum',
+             'ae': 'sum',
+             'r1': 'sum',
+             'r2': 'sum',
+             'r3': 'sum',
+             'r4': 'sum',
+             'read_type': 'min'}
+        ).reset_index()
+
+        df = df.sort_values(['cil', 'timestamp', 'season'])
+
+        for idx, row in df.iterrows():
+            ai_m = row.get('ai', 0.0)
+            ae_m = row.get('ae', 0.0)
+            if ai_m >= ae_m:
+                df.at[idx, 'ai'] = ai_m - ae_m
+                df.at[idx, 'ae'] = 0.0
+            else:
+                df.at[idx, 'ai'] = 0.0
+                df.at[idx, 'ae'] = ae_m - ai_m
+
+        return df
+
+    def writer(self):
+        """
+        MCIL345 contains hourly generation curves
+        :return: file path
+        """
+        daymin = self.file['timestamp'].min()
+        daymax = self.file['timestamp'].max()
+        self.measures_date = daymin
+        zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
+        while daymin <= daymax:
+            di = daymin
+            df = (datetime.strptime(daymin, DATETIME_HOUR_MASK) + timedelta(days=1)).strftime(DATETIME_HOUR_MASK)
+            self.measures_date = di
+            dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
+            # dataf['timestamp'] = dataf['timestamp'].apply(lambda x: x.strftime(DATETIME_HOUR_MASK))
+            # Avoid to generate file if dataframe is empty
+            if len(dataf):
+                existing_files = os.listdir('/tmp')
+                if existing_files:
+                    versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f]
+                    if versions:
+                        self.version = max(versions) + 1
+
+                file_path = os.path.join('/tmp', self.filename)
+                kwargs = {'sep': ';',
+                          'header': False,
+                          'columns': self.columns,
+                          'index': False,
+                          check_line_terminator_param(): ';\n'
+                          }
+                if self.default_compression:
+                    kwargs.update({'compression': self.default_compression})
+                dataf.to_csv(file_path, **kwargs)
+                zipped_file.write(file_path, arcname=os.path.basename(file_path))
+
+            daymin = df
+        zipped_file.close()
+        return zipped_file.filename

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -1018,7 +1018,6 @@ with description('A MCIL345QH'):
                    'ES0291000000004444QR1F001;2022/09/01 00:30;1;90;0;1;2;3;4;R\n'\
                    'ES0291000000005555QR1F001;2022/09/01 00:15;1;180;0;11;22;33;44;R\n'\
                    'ES0291000000005555QR1F001;2022/09/01 00:30;1;180;0;11;22;33;44;R\n'
-        import pudb; pu.db
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False) == expected
 
 with description('A CILDAT'):

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -18,6 +18,7 @@ from mesures.f1 import F1
 from mesures.f3 import F3
 from mesures.f5d import F5D
 from mesures.mcil345 import MCIL345
+from mesures.mcil345qh import MCIL345QH
 from mesures.medidas import MEDIDAS
 from mesures.p1 import P1
 from mesures.p1d import P1D
@@ -363,6 +364,58 @@ class SampleData:
             'r4': 44,
             'read_type': 'R'
             }]
+
+    @staticmethod
+    def get_sample_mcil345qh_data():
+        return [{
+            'cil': 'ES0291000000004444QR1F001',
+            'timestamp': '2022-09-01 00:15:00',
+            'season': 1,
+            'ae': 100,
+            'ai': 10,
+            'r1': 1,
+            'r2': 2,
+            'r3': 3,
+            'r4': 4,
+            'read_type': 'R'
+        },
+        {
+            'cil': 'ES0291000000004444QR1F001',
+            'timestamp': '2022-09-01 00:30:00',
+            'season': 1,
+            'ae': 100,
+            'ai': 10,
+            'r1': 1,
+            'r2': 2,
+            'r3': 3,
+            'r4': 4,
+            'read_type': 'R'
+        },
+        {
+            'cil': 'ES0291000000005555QR1F001',
+            'timestamp': '2022-09-01 00:15:00',
+            'season': 1,
+            'ae': 200,
+            'ai': 20,
+            'r1': 11,
+            'r2': 22,
+            'r3': 33,
+            'r4': 44,
+            'read_type': 'R'
+        },
+        {
+            'cil': 'ES0291000000005555QR1F001',
+            'timestamp': '2022-09-01 00:30:00',
+            'season': 1,
+            'ae': 200,
+            'ai': 20,
+            'r1': 11,
+            'r2': 22,
+            'r3': 33,
+            'r4': 44,
+            'read_type': 'R'
+        }
+        ]
 
     @staticmethod
     def get_sample_medidas_data():
@@ -936,6 +989,36 @@ with description('A MCIL345'):
         res = f.writer()
         expected = 'ES0291000000004444QR1F001;2022/09/01 01;1;90;0;1;2;3;4;R\n' \
                    'ES0291000000005555QR1F001;2022/09/01 01;1;180;0;11;22;33;44;R\n'
+        assert f.file[f.columns].to_csv(sep=';', header=None, index=False) == expected
+
+with description('A MCIL345QH'):
+    with it('is instance of MCIL345QH Class'):
+        data = SampleData().get_sample_mcil345qh_data()
+        f = MCIL345QH(data)
+        assert isinstance(f, MCIL345QH)
+
+    with it('has its class methods'):
+        data = SampleData().get_sample_mcil345qh_data()
+        f = MCIL345QH(data)
+        res = f.writer()
+        assert isinstance(f.cils, list)
+        assert isinstance(f.number_of_cils, int)
+        assert isinstance(f.ae, int)
+        assert isinstance(f.ai, int)
+        assert isinstance(f.r1, int)
+        assert isinstance(f.r2, int)
+        assert isinstance(f.r3, int)
+        assert isinstance(f.r4, int)
+
+    with it('has its expected content'):
+        data = SampleData().get_sample_mcil345qh_data()
+        f = MCIL345QH(data)
+        res = f.writer()
+        expected = 'ES0291000000004444QR1F001;2022/09/01 00:15;1;90;0;1;2;3;4;R\n'\
+                   'ES0291000000004444QR1F001;2022/09/01 00:30;1;90;0;1;2;3;4;R\n'\
+                   'ES0291000000005555QR1F001;2022/09/01 00:15;1;180;0;11;22;33;44;R\n'\
+                   'ES0291000000005555QR1F001;2022/09/01 00:30;1;180;0;11;22;33;44;R\n'
+        import pudb; pu.db
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False) == expected
 
 with description('A CILDAT'):


### PR DESCRIPTION
## Objetivos

- Añadir a la librería el soporte para el fichero `MCIL345QH`, que comunica a REE, en formato de curva cuarto-horaria, las medidas de instalaciones de `Autoconsumo` y de producción de energía eléctrica a partir de fuentes de energía renovables, cogeneración y residuos (`RECORE`) de tipo 3, 4 y 5.

![Captura desde 2023-05-24 12-02-27](https://github.com/gisce/mesures/assets/49635897/49dea134-5180-4228-a2dc-761ec2675292)

## Relacionado

- From https://github.com/gisce/erp/issues/17176
