### PR TITLE
Nuevo fichero de medidas F1QH para suministros de Tipo 1, 2 y 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 - `CUPSELECTRO`
 - `ENELECTROAUT`
 - `F1`
+- `F1QH`
 - `F3`
 - `F5`
 - `F5D`

--- a/mesures/f1qh.py
+++ b/mesures/f1qh.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from mesures.dates import *
+from mesures.f1 import F1
+from mesures.utils import check_line_terminator_param
+from zipfile import ZipFile
+import os
+import pandas as pd
+
+
+class F1QH(F1):
+    def __init__(self, data, distributor=None, compression='bz2', version=0):
+        """
+        :param data: list of dicts or absolute file_path
+        :param distributor: str distributor REE code
+        :param compression: 'bz2', 'gz'... OR False otherwise
+        """
+        super(F1QH, self).__init__(data=data, distributor=distributor, compression=compression, version=version)
+        self.prefix = 'F1QH'
+
+    def reader(self, filepath):
+        if isinstance(filepath, str):
+            df = pd.read_csv(
+                filepath, sep=';', names=self.columns
+            )
+        elif isinstance(filepath, list):
+            df = pd.DataFrame(data=filepath)
+        else:
+            raise Exception("Filepath must be an str or a list")
+
+        df['tipo_medida'] = 11
+
+        if 'firmeza' not in df:
+            df['firmeza'] = df['method'].apply(lambda x: 1 if x in (1, 3) else 0)
+
+        df = df.groupby(
+            ['cups', 'tipo_medida', 'timestamp', 'season', 'method', 'firmeza']
+            ).aggregate(
+            {
+                'ai': 'sum',
+                'ae': 'sum',
+                'r1': 'sum',
+                'r2': 'sum',
+                'r3': 'sum',
+                'r4': 'sum',
+            }
+        ).reset_index()
+
+        df['timestamp'] = df['timestamp'].apply(lambda x: x.strftime(DATETIME_HOUR_MASK))
+
+        df['res'] = 0
+        df['res2'] = 0
+        df = df[self.columns]
+        return df
+
+    def writer(self):
+        """
+        F1 contains a curve files diary on zip
+        :return: file path
+        """
+        daymin = self.file['timestamp'].min()
+        daymax = self.file['timestamp'].max()
+        self.measures_date = daymin
+        zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
+        while daymin <= daymax:
+            di = daymin
+            df = (datetime.strptime(daymin, DATETIME_HOUR_MASK) + timedelta(days=1)).strftime(DATETIME_HOUR_MASK)
+            self.measures_date = di
+            dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
+            # dataf['timestamp'] = dataf['timestamp'].apply(lambda x: x.strftime('%Y/%m/%d %H:%M'))
+            file_path = os.path.join('/tmp', self.filename)
+            kwargs = {'sep': ';',
+                      'header': False,
+                      'columns': self.columns,
+                      'index': False,
+                      check_line_terminator_param(): ';\n'
+                      }
+            if self.default_compression:
+                kwargs.update({'compression': self.default_compression})
+
+            dataf.to_csv(file_path, **kwargs)
+            daymin = df
+            zipped_file.write(file_path, arcname=os.path.basename(file_path))
+        zipped_file.close()
+        return zipped_file.filename

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -15,6 +15,7 @@ from mesures.cupsdat import CUPSDAT
 from mesures.dates import *
 from mesures.enelectroaut import ENELECTROAUT
 from mesures.f1 import F1
+from mesures.f1qh import F1QH
 from mesures.f3 import F3
 from mesures.f5d import F5D
 from mesures.mcil345 import MCIL345
@@ -88,6 +89,61 @@ class SampleData:
             data_f1.append(datas)
 
         return data_f1
+
+    @staticmethod
+    def get_sample_f1qh_data():
+        basic_f1qh = {
+            "cups": "ES0012345678912345670F",
+            "timestamp": "2022-01-01 00:15:00",
+            "tipo_medida": "p",
+            "season": "W",
+            "ae": 10,
+            "ai": 10,
+            "r1": 10,
+            "r2": 10,
+            "r3": 10,
+            "r4": 10,
+            "quality_ai": 0,
+            "quality_ae": 0,
+            "quality_r1": 0,
+            "quality_r2": 0,
+            "quality_r3": 0,
+            "quality_r4": 0,
+            "quality_res": 0,
+            "quality_res2": 0,
+            "method": 1,
+        }
+
+        data_f1qh = [basic_f1qh.copy()]
+
+        ts = "2022-01-01 00:15:00"
+        for x in range(50):
+            datas = basic_f1qh.copy()
+            ts = (datetime.strptime(ts, '%Y-%m-%d %H:%M:%S') + timedelta(minutes=15)).strftime('%Y-%m-%d %H:%M:%S')
+            ai = randint(0, 5000)
+            ae = randint(0, 2)
+            r1 = randint(0, 30)
+            r2 = randint(0, 4999)
+            r3 = randint(0, 30)
+            r4 = randint(0, 4999)
+            datas.update({'timestamp': ts, 'ai': ai, 'ae': ae, 'r1': r1, 'r2': r2, 'r3': r3, 'r4': r4})
+            data_f1qh.append(datas)
+
+        cups = "ES0012345678923456780F"
+        ts = "2022-01-01 00:00:00"
+        for x in range(70):
+            datas = basic_f1qh.copy()
+            ts = (datetime.strptime(ts, '%Y-%m-%d %H:%M:%S') + timedelta(minutes=15)).strftime('%Y-%m-%d %H:%M:%S')
+            ai = randint(0, 5000)
+            ae = randint(0, 2)
+            r1 = randint(0, 30)
+            r2 = randint(0, 10)
+            r3 = randint(0, 30)
+            r4 = randint(0, 10)
+            datas.update({'timestamp': ts, 'ai': ai, 'ae': ae, 'r1': r1, 'r2': r2, 'r3': r3, 'r4': r4, 'cups': cups})
+            data_f1qh.append(datas)
+
+        return data_f1qh
 
     @staticmethod
     def get_sample_p5d_data():
@@ -593,6 +649,34 @@ with description('An F1'):
         f = F1(data)
         res = f.writer()
         expected = 'ES0012345678912345670F;11;2022/01/01 01:00:00;0;10;10;10;10;10;10;0;0;1;1'
+        assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
+
+with description('An F1QH'):
+    with it('is instance of F1QH Class'):
+        data = SampleData().get_sample_f1qh_data()
+        f = F1QH(data)
+        assert isinstance(f, F1QH)
+
+    with it('a zip of raw Files'):
+        data = SampleData().get_sample_f1qh_data()
+        f = F1QH(data)
+        res = f.writer()
+        assert zipfile.is_zipfile(res)
+
+    with it('has its class methods'):
+        data = SampleData().get_sample_f1qh_data()
+        f = F1QH(data)
+        res = f.writer()
+        assert isinstance(f.total, (int, np.int64))
+        assert f.ai == f.total
+        assert isinstance(f.cups, list)
+        assert isinstance(f.number_of_cups, int)
+
+    with it('gets expected content'):
+        data = SampleData().get_sample_f1qh_data()
+        f = F1QH(data)
+        res = f.writer()
+        expected = 'ES0012345678912345670F;11;2022/01/01 00:15;0;10;10;10;10;10;10;0;0;1;1'
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
 
 


### PR DESCRIPTION
## Objetivos

- Añadir a la librería el soporte para el fichero `F1QH`, que comunica a REE, en formato de curva cuarto-horaria, las medidas de los suministros de tipo 1, 2 y 3.

![imagen](https://github.com/gisce/mesures/assets/49635897/ee84c649-1f73-45fd-9ee3-4ea24c221f92)

## Relacionado

- From https://github.com/gisce/erp/issues/17176
