### PR TITLE
Correcciones en los ficheros para suministros electrointensivos

### DIFF
--- a/.github/workflows/python2.7-app.yml
+++ b/.github/workflows/python2.7-app.yml
@@ -13,20 +13,30 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      # You can use PyPy versions in python-version.
+      # For example, pypy2 and pypy3
+      fail-fast: false
+      matrix:
+        python-version: [ "2.7" ]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 2.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: "2.7"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools
-        pip install coveralls
-        pip install -r requirements-dev.txt
-        pip install -e .
-    - name: Test with mamba
-      run: |
-        mamba --enable-coverage
+      - uses: actions/checkout@v3
+      - name: Install Python 2.7
+        run: |
+          sudo apt update
+          sudo apt install python2 python-pip
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python2 1
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 2
+          printf '1\n' | sudo update-alternatives --config python
+          cd /usr/bin
+          sudo ln -s /usr/bin/pip2 ./pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
+          pip install coveralls
+          pip install -r requirements-dev.txt
+          pip install -e .
+      - name: Test with mamba
+        run: |
+          mamba --enable-coverage

--- a/mesures/cumpelectro.py
+++ b/mesures/cumpelectro.py
@@ -3,7 +3,6 @@ from mesures.dates import *
 from mesures.headers import CUMPELECTRO_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
 from mesures.utils import check_line_terminator_param
-from zipfile import ZipFile
 import os
 import pandas as pd
 
@@ -17,6 +16,7 @@ class CUMPELECTRO(object):
         """
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
+        self.columns = columns
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'CUMPELECTRO'
@@ -45,13 +45,6 @@ class CUMPELECTRO(object):
             )
 
     @property
-    def zip_filename(self):
-        return "{prefix}_{distributor}_{timestamp}.zip".format(
-            prefix=self.prefix, distributor=self.distributor,
-            timestamp=self.generation_date.strftime('%Y%m%d')
-        )
-
-    @property
     def cups(self):
         return list(set(self.file['cups']))
 
@@ -61,32 +54,38 @@ class CUMPELECTRO(object):
 
     def reader(self, filepath):
         if isinstance(filepath, str):
-            df = pd.read_csv(filepath, sep=';', names=columns)
+            df = pd.read_csv(filepath, sep=';', names=self.columns)
         elif isinstance(filepath, list):
             df = pd.DataFrame(data=filepath)
         else:
             raise Exception("Filepath must be an str or a list")
         # TODO clean "cargos" and "peajes" for new supply points
-        df = df[columns]
+        df = df[self.columns]
         return df
 
     def writer(self):
         """
-        CUMPELECTRO contains a curve files diary on zip
+        CUMPELECTRO contains a file with a line for each CUPS
         :return: file path
         """
-        zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
+        existing_files = os.listdir('/tmp')
+        if existing_files:
+            versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f]
+            if versions:
+                self.version = max(versions) + 1
+
         file_path = os.path.join('/tmp', self.filename)
+
         kwargs = {'sep': ';',
                   'header': False,
-                  'columns': columns,
+                  'columns': self.columns,
                   'index': False,
                   check_line_terminator_param(): ';\n'
                   }
+
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})
 
         self.file.to_csv(file_path, **kwargs)
-        zipped_file.write(file_path, arcname=os.path.basename(file_path))
-        zipped_file.close()
-        return zipped_file.filename
+
+        return file_path

--- a/mesures/enelectroaut.py
+++ b/mesures/enelectroaut.py
@@ -3,7 +3,6 @@ from mesures.dates import *
 from mesures.headers import ENELECTROAUT_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
 from mesures.utils import check_line_terminator_param
-from zipfile import ZipFile
 import os
 import pandas as pd
 
@@ -17,6 +16,7 @@ class ENELECTROAUT(object):
         """
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
+        self.columns = columns
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'ENELECTROAUT'
@@ -45,13 +45,6 @@ class ENELECTROAUT(object):
             )
 
     @property
-    def zip_filename(self):
-        return "{prefix}_{distributor}_{timestamp}.zip".format(
-            prefix=self.prefix, distributor=self.distributor,
-            timestamp=self.generation_date.strftime('%Y%m%d')
-        )
-
-    @property
     def cups(self):
         return list(set(self.file['cups']))
 
@@ -61,33 +54,39 @@ class ENELECTROAUT(object):
 
     def reader(self, filepath):
         if isinstance(filepath, str):
-            df = pd.read_csv(filepath, sep=';', names=columns)
+            df = pd.read_csv(filepath, sep=';', names=self.columns)
         elif isinstance(filepath, list):
             df = pd.DataFrame(data=filepath)
         else:
             raise Exception("Filepath must be an str or a list")
         # TODO clean "projections" for new supply points
         # TODO use "projection" only under REE request ("F" field on CUPSELECTRO)
-        df = df[columns]
+        df = df[self.columns]
         return df
 
     def writer(self):
         """
-        ENELECTROAUT contains a curve files diary on zip
+        ENELECTROAUT contains a file with a line for each CUPS
         :return: file path
         """
-        zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
+        existing_files = os.listdir('/tmp')
+        if existing_files:
+            versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f]
+            if versions:
+                self.version = max(versions) + 1
+
         file_path = os.path.join('/tmp', self.filename)
+
         kwargs = {'sep': ';',
                   'header': False,
-                  'columns': columns,
+                  'columns': self.columns,
                   'index': False,
                   check_line_terminator_param(): ';\n'
                   }
+
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})
 
         self.file.to_csv(file_path, **kwargs)
-        zipped_file.write(file_path, arcname=os.path.basename(file_path))
-        zipped_file.close()
-        return zipped_file.filename
+
+        return file_path

--- a/mesures/potelectro.py
+++ b/mesures/potelectro.py
@@ -3,7 +3,6 @@ from mesures.dates import *
 from mesures.headers import POTELECTRO_HEADER as columns
 from mesures.parsers.dummy_data import DummyCurve
 from mesures.utils import check_line_terminator_param
-from zipfile import ZipFile
 import os
 import pandas as pd
 
@@ -17,6 +16,7 @@ class POTELECTRO(object):
         """
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
+        self.columns = columns
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'POTELECTRO'
@@ -45,13 +45,6 @@ class POTELECTRO(object):
             )
 
     @property
-    def zip_filename(self):
-        return "{prefix}_{distributor}_{timestamp}.zip".format(
-            prefix=self.prefix, distributor=self.distributor,
-            timestamp=self.generation_date.strftime('%Y%m%d')
-        )
-
-    @property
     def cups(self):
         return list(set(self.file['cups']))
 
@@ -61,7 +54,7 @@ class POTELECTRO(object):
 
     def reader(self, filepath):
         if isinstance(filepath, str):
-            df = pd.read_csv(filepath, sep=';', names=columns)
+            df = pd.read_csv(filepath, sep=';', names=self.columns)
         elif isinstance(filepath, list):
             df = pd.DataFrame(data=filepath)
         else:
@@ -69,26 +62,32 @@ class POTELECTRO(object):
         # TODO clean "powers" for new supply points
         # TODO clean "projections" for new supply points
         # TODO use "projection" only under REE request ("G" field on CUPSELECTRO)
-        df = df[columns]
+        df = df[self.columns]
         return df
 
     def writer(self):
         """
-        POTELECTRO contains a curve files diary on zip
+        POTELECTRO contains a file with a line for each CUPS
         :return: file path
         """
-        zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
+        existing_files = os.listdir('/tmp')
+        if existing_files:
+            versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f]
+            if versions:
+                self.version = max(versions) + 1
+
         file_path = os.path.join('/tmp', self.filename)
+
         kwargs = {'sep': ';',
                   'header': False,
-                  'columns': columns,
+                  'columns': self.columns,
                   'index': False,
                   check_line_terminator_param(): ';\n'
                   }
+
         if self.default_compression:
             kwargs.update({'compression': self.default_compression})
 
         self.file.to_csv(file_path, **kwargs)
-        zipped_file.write(file_path, arcname=os.path.basename(file_path))
-        zipped_file.close()
-        return zipped_file.filename
+
+        return file_path

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -907,11 +907,23 @@ with description('A CUMPELECTRO'):
         f = CUMPELECTRO(data)
         assert isinstance(f, CUMPELECTRO)
 
-    with it('a zip of raw Files'):
+    with it('is a BZ2 file'):
         data = SampleData().get_sample_cumpelectro_data()
         f = CUMPELECTRO(data)
-        res = f.writer()
-        assert zipfile.is_zipfile(res)
+        filepath = f.writer()
+        assert isinstance(filepath, str)
+        assert '.bz2' in f.filename
+        assert isinstance(f.filename, str)
+        assert '.bz2' in filepath
+
+    with it('is a raw file if no compression is used'):
+        data = SampleData().get_sample_cumpelectro_data()
+        f = CUMPELECTRO(data, compression=False)
+        filepath = f.writer()
+        assert isinstance(filepath, str)
+        assert '.bz2' not in f.filename
+        assert isinstance(f.filename, str)
+        assert '.bz2' not in filepath
 
     with it('has its class methods'):
         data = SampleData().get_sample_cumpelectro_data()
@@ -927,11 +939,23 @@ with description('A CUPSELECTRO'):
         f = CUPSELECTRO(data)
         assert isinstance(f, CUPSELECTRO)
 
-    with it('a zip of raw Files'):
+    with it('is a BZ2 file'):
         data = SampleData().get_sample_cupselectro_data()
         f = CUPSELECTRO(data)
-        res = f.writer()
-        assert zipfile.is_zipfile(res)
+        filepath = f.writer()
+        assert isinstance(filepath, str)
+        assert '.bz2' in f.filename
+        assert isinstance(f.filename, str)
+        assert '.bz2' in filepath
+
+    with it('is a raw file if no compression is used'):
+        data = SampleData().get_sample_cupselectro_data()
+        f = CUPSELECTRO(data, compression=False)
+        filepath = f.writer()
+        assert isinstance(filepath, str)
+        assert '.bz2' not in f.filename
+        assert isinstance(f.filename, str)
+        assert '.bz2' not in filepath
 
     with it('has its class methods'):
         data = SampleData().get_sample_cupselectro_data()
@@ -946,11 +970,23 @@ with description('A POTELECTRO'):
         f = POTELECTRO(data)
         assert isinstance(f, POTELECTRO)
 
-    with it('a zip of raw Files'):
+    with it('is a BZ2 file'):
         data = SampleData().get_sample_potelectro_data()
         f = POTELECTRO(data)
-        res = f.writer()
-        assert zipfile.is_zipfile(res)
+        filepath = f.writer()
+        assert isinstance(filepath, str)
+        assert '.bz2' in f.filename
+        assert isinstance(f.filename, str)
+        assert '.bz2' in filepath
+
+    with it('is a raw file if no compression is used'):
+        data = SampleData().get_sample_potelectro_data()
+        f = POTELECTRO(data, compression=False)
+        filepath = f.writer()
+        assert isinstance(filepath, str)
+        assert '.bz2' not in f.filename
+        assert isinstance(f.filename, str)
+        assert '.bz2' not in filepath
 
     with it('has its class methods'):
         data = SampleData().get_sample_potelectro_data()
@@ -965,11 +1001,23 @@ with description('A ENELECTROAUT'):
         f = ENELECTROAUT(data)
         assert isinstance(f, ENELECTROAUT)
 
-    with it('a zip of raw Files'):
+    with it('is a BZ2 file'):
         data = SampleData().get_sample_enelectroaut_data()
         f = ENELECTROAUT(data)
-        res = f.writer()
-        assert zipfile.is_zipfile(res)
+        filepath = f.writer()
+        assert isinstance(filepath, str)
+        assert '.bz2' in f.filename
+        assert isinstance(f.filename, str)
+        assert '.bz2' in filepath
+
+    with it('is a raw file if no compression is used'):
+        data = SampleData().get_sample_enelectroaut_data()
+        f = ENELECTROAUT(data, compression=False)
+        filepath = f.writer()
+        assert isinstance(filepath, str)
+        assert '.bz2' not in f.filename
+        assert isinstance(f.filename, str)
+        assert '.bz2' not in filepath
 
     with it('has its class methods'):
         data = SampleData().get_sample_enelectroaut_data()


### PR DESCRIPTION
## Objetivos

- Se han hecho correcciones en el tratamiento de los ficheros `CUPSELECTRO`, `CUMPELECTRO`, `POTELECTRO` y `ENELECTROAUT`.
- Se han actualizado los `tests` de los cuatro ficheros.
- Se ha arreglado el testeo en `Python 2.7`.

## Comportamiento antiguo

- Los ficheros no soportan sistema de versionado.
- Los ficheros se exportan en formato de fichero ZIP.

## Comportamiento nuevo

- Los ficheros soportan sistema de versionado.
- Los ficheros se exportan en formato de fichero BZ2 o, en caso de ajustarse por parámetro, en formato de fichero plano.

## Relacionado

- Fixes https://github.com/gisce/mesures/pull/29

## Checklist

- [x] Test code
