### PR TITLE
Las bajas de agregacions deben comunicarse antes que las altas de agregaciones en el fichero AGRECL

### DIFF
--- a/mesures/agrecl.py
+++ b/mesures/agrecl.py
@@ -68,7 +68,7 @@ class AGRECL(object):
         df['data_alta'] = df['data_alta'].apply(lambda x: x.strftime('%Y/%m/%d %H'))
         df['data_baixa'] = df['data_baixa'].apply(
             lambda x: '' if not isinstance(x, pd.Timestamp) else x.strftime('%Y/%m/%d %H'))
-        df = df.sort_values(['origen', 'comercialitzadora'])
+        df = df.sort_values(by=['origen', 'comercialitzadora'], ascending=[False, True])
         df = df[columns]
         return df
 


### PR DESCRIPTION
## Objetivos

- Las bajas de niveles de agregación de un fichero `AGRECL` deben informarse antes que las altas, por si en un mismo fichero hay una baja y un alta del mismo nivel de agregación.

## Comportamiento antiguo

- Las líneas se ordenan de forma ascendente por `origen` y `comercializador`.

## Comportamiento nuevo

- Las líneas se ordenan de forma descendente por `origen` y de forma ascendente por `comercializador`.
