### PR TITLE
Añadir control de versión incremental en la generación de ficheros P5D

### DIFF
--- a/mesures/p5d.py
+++ b/mesures/p5d.py
@@ -104,6 +104,12 @@ class P5D(object):
         P5D contains an hourly raw curve
         :return: file path
         """
+        existing_files = os.listdir('/tmp')
+        if existing_files:
+            versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f]
+            if versions:
+                self.version = max(versions) + 1
+
         file_path = os.path.join('/tmp', self.filename)
         kwargs = {'sep': ';',
                   'header': False,


### PR DESCRIPTION
## Objetivos

- Se ha añadido un control de versión para que, si existe un fichero con el mismo nombre que el que estamos generando, se incremente en 1 su número de versión para evitar errores al publicarlo.

## Relacionado

- Fixes https://github.com/gisce/mesures/pull/5
