### PR TITLE
Añadir soporte para compresión ZIP en los ficheros F5D

### DIFF
--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -83,7 +83,7 @@ class F5D(F5):
         existing_files = os.listdir('/tmp')
         if self.default_compression != 'zip':
             if existing_files:
-                versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f]
+                versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
                 if versions:
                     self.version = max(versions) + 1
 
@@ -102,7 +102,7 @@ class F5D(F5):
             zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
             file_path = os.path.join('/tmp', self.filename)
             kwargs.update({'compression': False})
-            self.file.to_csv(file_path, **kwargs)
+            self.file.to_csv(file_path)
             zipped_file.write(file_path, arcname=os.path.basename(file_path))
             file_path = zipped_file.filename
         else:

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -675,6 +675,13 @@ with description('An F5D'):
         expected = 'ES0012345678912345670F;2020/01/01 01:00;0;0;0;0;0;0;0;1;0;FE20214444'
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
 
+    with it('gets expected content when uses ZIP compression'):
+        data = SampleData().get_sample_f5d_data()
+        f = F5D(data, compression='zip')
+        res = f.writer()
+        expected = 'ES0012345678912345670F;2020/01/01 01:00;0;0;0;0;0;0;0;1;0;FE20214444'
+        assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
+        assert '.zip' in res
 
 with description('An F1'):
     with it('is instance of F1 Class'):


### PR DESCRIPTION
## Objetivos

- Añadir, además de la compresión `bz2`, soporte también para fichero `zip`.
- Si se exporta un `F5D` en formato de fichero `zip` no se utiliza el control de versiones.

## Checklist

- [x] Test code
