### PR TITLE
Añadir codificación de caracteres a los ficheros REOBJEAGRECL y REOBJEINCL

### DIFF
--- a/mesures/reobjeagrecl.py
+++ b/mesures/reobjeagrecl.py
@@ -83,7 +83,8 @@ class REOBJEAGRECL(object):
                   'columns': self.columns,
                   'index': False,
                   'float_format': '%.2f',
-                  check_line_terminator_param(): ';\n'
+                  check_line_terminator_param(): ';\n',
+                  'encoding': 'iso-8859-15',
                   }
 
         if self.default_compression:


### PR DESCRIPTION
## Objetivos

- Los ficheros `REOBJEAGRECL` y `REOBJEINCL` deben soportar caracteres especiales como tildes, eñes, etc.

## Comportamiento antiguo

- No se usa codificación.

## Comportamiento nuevo

- Se usa codificación `iso-8859-15`.

## Checklist

- [ ] Test code
