### PR TITLE
Ajustes en la generación de ficheros CUPSDAT (ISP Noviembre 2024)

### DIFF
--- a/mesures/cupsdat.py
+++ b/mesures/cupsdat.py
@@ -8,17 +8,17 @@ import pandas as pd
 
 
 class CUPSDAT(object):
-    def __init__(self, data, distributor=None, compression='bz2', columns=COLUMNS, include_measure_indicator=False,
+    def __init__(self, data, distributor=None, compression='bz2', columns=COLUMNS, include_measure_type_indicator=False,
                  version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
         :param compression: 'bz2', 'gz'... OR False otherwise
-        :param include_measure_indicator: boolean (indicates if new columns is included)
+        :param include_measure_type_indicator: boolean (indicates if new columns is included)
         """
         data = DummyKeys(data).data
         self.columns = columns
-        if include_measure_indicator:
+        if include_measure_type_indicator:
             self.columns = COLUMNS_2024
         self.file = self.reader(data)
         self.generation_date = datetime.now()

--- a/mesures/headers.py
+++ b/mesures/headers.py
@@ -192,6 +192,10 @@ CUPSDAT_HEADER = [
     'tension'                       # str(2)
 ]
 
+CUPSDAT_HEADER_2024 = CUPSDAT_HEADER + [
+    'indicador_envio_medida'        # str(1) in ('Q', 'H')
+]
+
 CUPSELECTRO_HEADER = [
     'cups',                     # str(22)
     'cif_empresa',              # str(9)

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -645,6 +645,12 @@ class SampleData:
         }]
 
     @staticmethod
+    def get_sample_cupsdat_data_isp_2024():
+        res = SampleData().get_sample_cupsdat_data()
+        res[0].update({'indicador_envio_medida': 'Q'})
+        return res
+
+    @staticmethod
     def get_sample_cups45_data():
         return [{
             'cups': 'ES0291000000004444QR1F',
@@ -1292,6 +1298,21 @@ with description('A CUPSDAT'):
                    'E2;6A;G0;A;GI;400;400;400;400;400;500;1091;2022/10/01 01;2022/10/17 00;17005;S;27\n' \
                    'ES0291000000005555QR1F;CUPS de Demo 02;X0005555;4444;5555;2;' \
                    'E2;6A;G0;A;GI;400;400;400;400;400;500;1091;2022/10/17 01;3000/01/01 00;17005;S;27\n'
+        assert f.file[f.columns].to_csv(sep=';', header=None, index=False) == expected
+
+    with it('has new field indicador_envio_medida if it is specified in function call'):
+        data = SampleData().get_sample_cupsdat_data_isp_2024()
+        f = CUPSDAT(data, include_measure_indicator=True)
+        assert 'indicador_envio_medida' in f.columns
+
+    with it('has its expected content when indicador_envio_medida is included'):
+        data = SampleData().get_sample_cupsdat_data_isp_2024()
+        f = CUPSDAT(data, include_measure_indicator=True)
+        res = f.writer()
+        expected = 'ES0291000000004444QR1F;CUPS de Demo 01;X0004444;4444;5555;2;' \
+                   'E2;6A;G0;A;GI;400;400;400;400;400;500;1091;2022/10/01 01;2022/10/17 00;17005;S;27;Q\n' \
+                   'ES0291000000005555QR1F;CUPS de Demo 02;X0005555;4444;5555;2;' \
+                   'E2;6A;G0;A;GI;400;400;400;400;400;500;1091;2022/10/17 01;3000/01/01 00;17005;S;27;Q\n'
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False) == expected
 
 with description('A CUPS45'):

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -1302,12 +1302,12 @@ with description('A CUPSDAT'):
 
     with it('has new field indicador_envio_medida if it is specified in function call'):
         data = SampleData().get_sample_cupsdat_data_isp_2024()
-        f = CUPSDAT(data, include_measure_indicator=True)
+        f = CUPSDAT(data, include_measure_type_indicator=True)
         assert 'indicador_envio_medida' in f.columns
 
     with it('has its expected content when indicador_envio_medida is included'):
         data = SampleData().get_sample_cupsdat_data_isp_2024()
-        f = CUPSDAT(data, include_measure_indicator=True)
+        f = CUPSDAT(data, include_measure_type_indicator=True)
         res = f.writer()
         expected = 'ES0291000000004444QR1F;CUPS de Demo 01;X0004444;4444;5555;2;' \
                    'E2;6A;G0;A;GI;400;400;400;400;400;500;1091;2022/10/01 01;2022/10/17 00;17005;S;27;Q\n' \


### PR DESCRIPTION
## Objetivos

- Si se indica al crear la clase `CUPSDAT`, el fichero resultante tiene que tener en cuenta el nuevo campo `indicador_envio_medida` indicando si un CUPS publica medida cuartohoraria (`Q`) o no (`H`).
- Implementar tests para mantener el nuevo formato y también el antiguo para periodos previos a noviembre de 2024.

## Relacionado

- From https://github.com/gisce/erp/issues/17176

![imagen](https://github.com/user-attachments/assets/52779f8f-55e0-4ae6-b679-e8389d515fb8)

## Checklist

- [x] Test code
