### PR TITLE
Permitir decimales en ficheros F1 y F1QH

### DIFF
--- a/mesures/f1.py
+++ b/mesures/f1.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 
 class F1(object):
-    def __init__(self, data, distributor=None, compression='bz2', version=0):
+    def __init__(self, data, distributor=None, compression='bz2', allow_decimals=False, version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
@@ -24,6 +24,7 @@ class F1(object):
         self.version = version
         self.distributor = distributor
         self.default_compression = compression
+        self.allow_decimals = allow_decimals
 
     def __repr__(self):
         return "{}: {} kWh".format(self.filename, self.total)
@@ -129,6 +130,11 @@ class F1(object):
 
         df['res'] = 0
         df['res2'] = 0
+
+        if not self.allow_decimals:
+            for key in ['ai', 'ae', 'r1', 'r2', 'r3', 'r4']:
+                df[key] = df[key].astype('int')
+
         df = df[self.columns]
         return df
 

--- a/mesures/f1.py
+++ b/mesures/f1.py
@@ -18,13 +18,13 @@ class F1(object):
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
         self.columns = COLUMNS
+        self.allow_decimals = allow_decimals
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'F1'
         self.version = version
         self.distributor = distributor
         self.default_compression = compression
-        self.allow_decimals = allow_decimals
 
     def __repr__(self):
         return "{}: {} kWh".format(self.filename, self.total)

--- a/mesures/f1qh.py
+++ b/mesures/f1qh.py
@@ -8,13 +8,14 @@ import pandas as pd
 
 
 class F1QH(F1):
-    def __init__(self, data, distributor=None, compression='bz2', version=0):
+    def __init__(self, data, distributor=None, compression='bz2', allow_decimals=False, version=0):
         """
         :param data: list of dicts or absolute file_path
         :param distributor: str distributor REE code
         :param compression: 'bz2', 'gz'... OR False otherwise
         """
-        super(F1QH, self).__init__(data=data, distributor=distributor, compression=compression, version=version)
+        super(F1QH, self).__init__(data=data, distributor=distributor, compression=compression,
+                                   allow_decimals=allow_decimals, version=version)
         self.prefix = 'F1QH'
 
     def reader(self, filepath):
@@ -49,6 +50,11 @@ class F1QH(F1):
 
         df['res'] = 0
         df['res2'] = 0
+
+        if not self.allow_decimals:
+            for key in ['ai', 'ae', 'r1', 'r2', 'r3', 'r4']:
+                df[key] = df[key].astype('int')
+
         df = df[self.columns]
         return df
 

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -100,6 +100,34 @@ class SampleData:
         return data_f1
 
     @staticmethod
+    def get_sample_data_with_decimals():
+        basic_f1 = {
+            "cups": "ES0012345678912345670F",
+            "timestamp": "2022-01-01 01:00:00",
+            "tipo_medida": "p",
+            "season": "W",
+            "ai": 10.1,
+            "ae": 10.2,
+            "r1": 10.3,
+            "r2": 10.4,
+            "r3": 10.5,
+            "r4": 10.6,
+            "quality_ai": 0,
+            "quality_ae": 0,
+            "quality_r1": 0,
+            "quality_r2": 0,
+            "quality_r3": 0,
+            "quality_r4": 0,
+            "quality_res": 0,
+            "quality_res2": 0,
+            "method": 1,
+        }
+
+        data_f1 = [basic_f1.copy()]
+
+        return data_f1
+
+    @staticmethod
     def get_sample_p2d_data():
         basic_p2d = {
             "cups": "ES0012345678912345670F",
@@ -969,6 +997,20 @@ with description('An F1'):
 
     with it('gets expected content'):
         data = SampleData().get_sample_data()
+        f = F1(data)
+        res = f.writer()
+        expected = 'ES0012345678912345670F;11;2022/01/01 01:00:00;0;10;10;10;10;10;10;0;0;1;1'
+        assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
+
+    with it('allows decimals if specified'):
+        data = SampleData().get_sample_data_with_decimals()
+        f = F1(data, allow_decimals=True)
+        res = f.writer()
+        expected = 'ES0012345678912345670F;11;2022/01/01 01:00:00;0;10.1;10.2;10.3;10.4;10.5;10.6;0;0;1;1'
+        assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
+
+    with it('truncate decimals if not allow_decimals parameter is specified'):
+        data = SampleData().get_sample_data_with_decimals()
         f = F1(data)
         res = f.writer()
         expected = 'ES0012345678912345670F;11;2022/01/01 01:00:00;0;10;10;10;10;10;10;0;0;1;1'


### PR DESCRIPTION
## Objetivos

- Permitir mediante un parámetro opcional, generar ficheros `F1` o `F1QH` no estándar, para ser usados fuera de `SIMEL`.

## Relacionado

- Requires https://github.com/gisce/mesures/pull/53

## Checklist

- [x] Test code
