### PR TITLE
Mejorar versionado de ficheros F1 y F1QH

### DIFF
--- a/mesures/f1qh.py
+++ b/mesures/f1qh.py
@@ -66,25 +66,33 @@ class F1QH(F1):
         daymin = self.file['timestamp'].min()
         daymax = self.file['timestamp'].max()
         self.measures_date = daymin
+
+        existing_files = os.listdir('/tmp')
+        if existing_files:
+            versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f]
+            if versions:
+                self.version = max(versions) + 1
+
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin
             df = (datetime.strptime(daymin, DATETIME_HOUR_MASK) + timedelta(days=1)).strftime(DATETIME_HOUR_MASK)
             self.measures_date = di
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
-            # dataf['timestamp'] = dataf['timestamp'].apply(lambda x: x.strftime('%Y/%m/%d %H:%M'))
-            file_path = os.path.join('/tmp', self.filename)
-            kwargs = {'sep': ';',
-                      'header': False,
-                      'columns': self.columns,
-                      'index': False,
-                      check_line_terminator_param(): ';\n'
-                      }
-            if self.default_compression:
-                kwargs.update({'compression': self.default_compression})
+            # Avoid to generate file if dataframe is empty
+            if len(dataf):
+                file_path = os.path.join('/tmp', self.filename)
+                kwargs = {'sep': ';',
+                          'header': False,
+                          'columns': self.columns,
+                          'index': False,
+                          check_line_terminator_param(): ';\n'
+                          }
+                if self.default_compression:
+                    kwargs.update({'compression': self.default_compression})
+                dataf.to_csv(file_path, **kwargs)
+                zipped_file.write(file_path, arcname=os.path.basename(file_path))
 
-            dataf.to_csv(file_path, **kwargs)
             daymin = df
-            zipped_file.write(file_path, arcname=os.path.basename(file_path))
         zipped_file.close()
         return zipped_file.filename

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -980,7 +980,7 @@ with description('An F1'):
         f = F1(data)
         assert isinstance(f, F1)
 
-    with it('is a zip of raw Files'):
+    with it('is a zip of raw files'):
         data = SampleData().get_sample_data()
         f = F1(data)
         res = f.writer()
@@ -1009,7 +1009,7 @@ with description('An F1'):
         expected = 'ES0012345678912345670F;11;2022/01/01 01:00:00;0;10.1;10.2;10.3;10.4;10.5;10.6;0;0;1;1'
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
 
-    with it('truncate decimals if not allow_decimals parameter is specified'):
+    with it('truncates decimals if not allow_decimals parameter is specified'):
         data = SampleData().get_sample_data_with_decimals()
         f = F1(data)
         res = f.writer()
@@ -1022,7 +1022,7 @@ with description('An F1QH'):
         f = F1QH(data)
         assert isinstance(f, F1QH)
 
-    with it('a zip of raw Files'):
+    with it('is a zip of raw files'):
         data = SampleData().get_sample_f1qh_data()
         f = F1QH(data)
         res = f.writer()

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -980,7 +980,7 @@ with description('An F1'):
         f = F1(data)
         assert isinstance(f, F1)
 
-    with it('a zip of raw Files'):
+    with it('is a zip of raw Files'):
         data = SampleData().get_sample_data()
         f = F1(data)
         res = f.writer()


### PR DESCRIPTION
## Objetivos

- Los ficheros ZIP que contienen los `F1` o `F1QH` deben mostrar versionado, para identificar al momento la versión de los ficheros contenidos, sin tener que abrir ni descomprimir el ZIP.

## Comportamiento antiguo

- Los ficheros ZIP no tienen versión.

## Comportamiento nuevo

- Los ficheros ZIP tienen versión.

## Checklist

- [x] Test code
