### PR TITLE
Correcciones en la generación de ficheros PMEST en Distribuidora

### DIFF
--- a/mesures/parsers/dummy_data.py
+++ b/mesures/parsers/dummy_data.py
@@ -42,7 +42,7 @@ class DummyCurve(object):
                 except ValueError:
                     # str season
                     data['season'] = 0 if data['season'].lower() == 'w' else 1
-            if 'kind_fact' in data:
+            if 'kind_fact' in data and not 'method' in data:
                 try:
                     data['method'] = int(data.pop('kind_fact'))
                 except ValueError:

--- a/mesures/pmest.py
+++ b/mesures/pmest.py
@@ -17,6 +17,7 @@ class PMEST(object):
         """
         if isinstance(data, list):
             data = DummyCurve(data).curve_data
+        self.columns = columns
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'PMEST'
@@ -93,7 +94,7 @@ class PMEST(object):
     def reader(self, filepath):
         if isinstance(filepath, str):
             df = pd.read_csv(
-                filepath, sep=';', names=columns
+                filepath, sep=';', names=self.columns
             )
         elif isinstance(filepath, list):
             df = pd.DataFrame(data=filepath)
@@ -120,7 +121,7 @@ class PMEST(object):
                 'r4': 'sum',
             }
         ).reset_index()
-        df = df[columns]
+        df = df[self.columns]
         return df
 
     def writer(self):
@@ -138,10 +139,11 @@ class PMEST(object):
             self.measures_date = di
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             dataf['timestamp'] = dataf.apply(lambda row: row['timestamp'].strftime('%Y/%m/%d %H'), axis=1)
+            dataf['timestamp'] = dataf['timestamp'].astype(str)
             file_path = os.path.join('/tmp', self.filename)
             kwargs = {'sep': ';',
                       'header': False,
-                      'columns': columns,
+                      'columns': self.columns,
                       'index': False,
                       check_line_terminator_param(): ';\n'
                       }


### PR DESCRIPTION
## Objetivos

- Los ficheros `PMEST` no se generan en el formato esperado. Se debe corregir la pérdida del valor del campo `método de optención`.
- Se implementará una batería de tests para el fichero, como la tienen el resto de ficheros de a librería, para garantizar el formato y el funcionamiento.

## Relacionado

- Fixes https://github.com/gisce/erp/pull/12757

![imagen](https://github.com/user-attachments/assets/296fbcd3-c9da-4d56-8016-6245f9482129)

## Checklist

- [x] Test code
