### PR TITLE
No corregir el tipo de envío de medida en el fichero CUPSDAT

### DIFF
--- a/mesures/cupsdat.py
+++ b/mesures/cupsdat.py
@@ -74,12 +74,12 @@ class CUPSDAT(object):
             if row['fecha_hora_final_vigencia'] == ''
             else datetime.strptime(row['fecha_hora_final_vigencia'], '%Y-%m-%d %H').strftime(DATE_MASK), axis=1)
 
-        # # Patch indicador_tipo_medida if needed
-        # if 'indicador_envio_medida' in self.columns:
-        #     df['indicador_envio_medida'] = df.apply(
-        #         lambda row: 'Q'
-        #         if row['tipo'] in ('1', '2') or not row.get('indicador_envio_medida', False)
-        #         else row['indicador_envio_medida'], axis=1)
+        # Patch indicador_tipo_medida if needed
+        if 'indicador_envio_medida' in self.columns:
+            df['indicador_envio_medida'] = df.apply(
+                lambda row: 'H'
+                if not row.get('indicador_envio_medida', False)
+                else row['indicador_envio_medida'], axis=1)
 
         return df[self.columns]
 

--- a/mesures/cupsdat.py
+++ b/mesures/cupsdat.py
@@ -74,13 +74,6 @@ class CUPSDAT(object):
             if row['fecha_hora_final_vigencia'] == ''
             else datetime.strptime(row['fecha_hora_final_vigencia'], '%Y-%m-%d %H').strftime(DATE_MASK), axis=1)
 
-        # Patch indicador_tipo_medida if needed
-        if 'indicador_envio_medida' in self.columns:
-            df['indicador_envio_medida'] = df.apply(
-                lambda row: 'H'
-                if not row.get('indicador_envio_medida', False)
-                else row['indicador_envio_medida'], axis=1)
-
         return df[self.columns]
 
     def writer(self):

--- a/mesures/cupsdat.py
+++ b/mesures/cupsdat.py
@@ -74,12 +74,12 @@ class CUPSDAT(object):
             if row['fecha_hora_final_vigencia'] == ''
             else datetime.strptime(row['fecha_hora_final_vigencia'], '%Y-%m-%d %H').strftime(DATE_MASK), axis=1)
 
-        # Patch indicador_tipo_medida if needed
-        if 'indicador_envio_medida' in self.columns:
-            df['indicador_envio_medida'] = df.apply(
-                lambda row: 'Q'
-                if row['tipo'] in ('1', '2') or not row.get('indicador_envio_medida', False)
-                else row['indicador_envio_medida'], axis=1)
+        # # Patch indicador_tipo_medida if needed
+        # if 'indicador_envio_medida' in self.columns:
+        #     df['indicador_envio_medida'] = df.apply(
+        #         lambda row: 'Q'
+        #         if row['tipo'] in ('1', '2') or not row.get('indicador_envio_medida', False)
+        #         else row['indicador_envio_medida'], axis=1)
 
         return df[self.columns]
 

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -712,6 +712,7 @@ class SampleData:
     def get_sample_cupsdat_data_isp_2024():
         res = SampleData().get_sample_cupsdat_data()
         res[0].update({'indicador_envio_medida': 'Q'})
+        res[1].update({'indicador_envio_medida': 'Q'})
         return res
 
     @staticmethod


### PR DESCRIPTION
## Objetivos

- El campo `indicador_envio_medida` debe informarse obligatoriamente en los datos de entrada. No se puede asumir, en caso de no informarse.

## Relacionado

- From https://github.com/gisce/mesures/pull/76
