### PR TITLE
Usar codificación ISO-8859-15 en la generación de ficheros CUPSDAT

### DIFF
--- a/.github/workflows/python2.7-app.yml
+++ b/.github/workflows/python2.7-app.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       # You can use PyPy versions in python-version.
       # For example, pypy2 and pypy3

--- a/mesures/cupsdat.py
+++ b/mesures/cupsdat.py
@@ -92,6 +92,7 @@ class CUPSDAT(object):
                   'header': False,
                   'columns': self.columns,
                   'index': False,
+                  'encoding': 'iso8859-15',
                   check_line_terminator_param(): ';\n'
                   }
 

--- a/mesures/cupsdat.py
+++ b/mesures/cupsdat.py
@@ -92,7 +92,7 @@ class CUPSDAT(object):
                   'header': False,
                   'columns': self.columns,
                   'index': False,
-                  'encoding': 'iso8859-15',
+                  'encoding': 'iso-8859-15',
                   check_line_terminator_param(): ';\n'
                   }
 


### PR DESCRIPTION
## Objetivos

- Especificar codificación de caracteres `iso-8859-15` en la generación de ficheros `CUPSDAT` dado que estos incluyen un campo "descripción" que puede contener caracteres especiales, dado que se informa el nombre del titular.
- Extra: Se ha arreglado la batería de tests de "Python 2.7", haciéndola ejecutarse sobre `Ubuntu 22.04`.
