### PR TITLE
FIX Corregir la generación de F5D's cuando se comprime el F5D con zip

### DIFF
--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -133,7 +133,7 @@ class F5D(F5):
             self.default_compression = False
             zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
             file_path = os.path.join('/tmp', self.filename)
-            kwargs.update({'compression': False})
+            kwargs.pop('compression')
             self.file.to_csv(file_path, **kwargs)
             zipped_file.write(file_path, arcname=os.path.basename(file_path))
             file_path = zipped_file.filename

--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -134,7 +134,7 @@ class F5D(F5):
             zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
             file_path = os.path.join('/tmp', self.filename)
             kwargs.update({'compression': False})
-            self.file.to_csv(file_path)
+            self.file.to_csv(file_path, **kwargs)
             zipped_file.write(file_path, arcname=os.path.basename(file_path))
             file_path = zipped_file.filename
         else:


### PR DESCRIPTION
## Objetivos

- Los ficheros F5D generados no són correctos cuando se comprimen con ZIP.

## Comportamiento antiguo

- Se generaban ficheros no f5d

## Comportamiento nuevo

- Se generan F5D's comprimidos con zip con el formato correcto

## Relacionado

fixes #62
## Checklist

- [ ] Test code
