### PR TITLE
FIX F5D magnitudes de energia saliente fix

### DIFF
--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -10,7 +10,7 @@ import pandas as pd
 TYPES = DTYPES.copy()
 TYPES.update({'factura': 'category'})
 ENERGY_MAGNS = ['ai', 'ae', 'r1', 'r2', 'r3', 'r4']
-CNMC_ENERGY_MAGNS = ['ai_fix', 'ao_fix']
+CNMC_ENERGY_MAGNS = ['ai_fix', 'ae_fix']
 
 class F5D(F5):
     def __init__(self, data, file_format='REE', distributor=None, comer=None, compression='bz2', columns=COLUMNS, dtypes=TYPES, version=0):
@@ -58,11 +58,11 @@ class F5D(F5):
         return res
 
     @property
-    def ao_fix(self):
+    def ae_fix(self):
         if not self.file_format == 'CNMC':
             res = 0
         else:
-            res = int(self.file['ao_fix'].sum())
+            res = int(self.file['ae_fix'].sum())
         return res
 
     def cut_by_dates(self, di, df):
@@ -89,7 +89,7 @@ class F5D(F5):
 
         agregates = {'ai': 'sum', 'ae': 'sum', 'r1': 'sum', 'r2': 'sum', 'r3': 'sum', 'r4': 'sum'}
         if self.file_format == 'CNMC':
-            agregates.update({'ai_fix': 'sum', 'ao_fix': 'sum'})
+            agregates.update({'ai_fix': 'sum', 'ae_fix': 'sum'})
 
         df = df.groupby(['cups', 'timestamp', 'season', 'firmeza', 'method', 'factura']).aggregate(
             agregates).reset_index()

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -320,7 +320,7 @@ class SampleData:
             'invoice_number': 'FE20214444'
         }
         if file_format == 'CNMC':
-            basic_f5d.update({'ao_fix': 1000, 'ai_fix': 1000})
+            basic_f5d.update({'ae_fix': 1000, 'ai_fix': 1000})
         data_f5d = [basic_f5d.copy()]
         ts = "2020-01-01 01:00:00"
         for x in range(50):
@@ -1015,7 +1015,7 @@ with description('An F5D'):
         f = F5D(data, file_format='CNMC')
         res = f.writer()
         assert isinstance(f.ai_fix, (int, np.int64))
-        assert isinstance(f.ao_fix, (int, np.int64))
+        assert isinstance(f.ae_fix, (int, np.int64))
 
     with it('with CNMC format gets expected content'):
         data = SampleData().get_sample_f5d_data(file_format='CNMC')


### PR DESCRIPTION
## Objetivos

- Corregir las magnitudes para el formato `CNCM` cambiando `ao_fix` por `ae_fix`



## Relacionado

Bug Origin: 
* https://github.com/gisce/mesures/pull/82


