### PR TITLE
IMP el campo method en ficheros re REE (F1, F1QH, etc...) no puede ser 0

### DIFF
--- a/mesures/parsers/dummy_data.py
+++ b/mesures/parsers/dummy_data.py
@@ -45,6 +45,9 @@ class DummyCurve(object):
             if 'kind_fact' in data and not 'method' in data:
                 try:
                     data['method'] = int(data.pop('kind_fact'))
+                    # 0 is not a valid method
+                    if data['method'] < 1:
+                        data['method'] = 1
                 except ValueError:
                     data['method'] = 1
             if 'firm_fact' in data:


### PR DESCRIPTION
## Objetivos

- Que el campo method de algunos ficheros de REE sea correcto cuando no se informa. El valor por defecto será 1

## Comportamiento antiguo

- Se informava con el valor incorrecto 0

## Comportamiento nuevo

- Se informa cómo 1 si no está disponible en la curva leida

## Relacionado

TASK-75148

## Checklist

- [ ] Test code
