### PR TITLE
Mejoras en el versionado de los ficheros

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,8 @@
 
 ## Relacionado
 
-*Puedes ver todas las [posibles palabras para accionesa automáticas con el mensaje](https://help.github.com/articles/closing-issues-using-keywords/)*
+- Puedes ver todas las [posibles palabras para accionesa automáticas con el mensaje](https://help.github.com/articles/closing-issues-using-keywords/)*
+- Origen de la tarea: TASK-
 
 ## Checklist
 

--- a/mesures/f1.py
+++ b/mesures/f1.py
@@ -149,9 +149,9 @@ class F1(object):
 
         existing_files = os.listdir('/tmp')
         if existing_files:
-            versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f]
-            if versions:
-                self.version = max(versions) + 1
+            zip_versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
+            if zip_versions:
+                self.version = max(zip_versions) + 1
 
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
@@ -161,6 +161,10 @@ class F1(object):
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             # Avoid to generate file if dataframe is empty
             if len(dataf):
+                if existing_files:
+                    versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
+                    if versions:
+                        self.version = max(versions) + 1
                 file_path = os.path.join('/tmp', self.filename)
                 kwargs = {'sep': ';',
                           'header': False,

--- a/mesures/f1.py
+++ b/mesures/f1.py
@@ -153,6 +153,8 @@ class F1(object):
             if zip_versions:
                 self.version = max(zip_versions) + 1
 
+        zip_measures_date = self.measures_date
+        zip_version = self.version
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin
@@ -161,6 +163,7 @@ class F1(object):
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             # Avoid to generate file if dataframe is empty
             if len(dataf):
+                existing_files = os.listdir('/tmp')
                 if existing_files:
                     versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
                     if versions:
@@ -179,4 +182,6 @@ class F1(object):
 
             daymin = df
         zipped_file.close()
+        self.measures_date = zip_measures_date
+        self.version = zip_version
         return zipped_file.filename

--- a/mesures/f1qh.py
+++ b/mesures/f1qh.py
@@ -73,6 +73,8 @@ class F1QH(F1):
             if zip_versions:
                 self.version = max(zip_versions) + 1
 
+        zip_measures_date = self.measures_date
+        zip_version = self.version
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin
@@ -81,6 +83,7 @@ class F1QH(F1):
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             # Avoid to generate file if dataframe is empty
             if len(dataf):
+                existing_files = os.listdir('/tmp')
                 if existing_files:
                     versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
                     if versions:
@@ -99,4 +102,6 @@ class F1QH(F1):
 
             daymin = df
         zipped_file.close()
+        self.measures_date = zip_measures_date
+        self.version = zip_version
         return zipped_file.filename

--- a/mesures/f1qh.py
+++ b/mesures/f1qh.py
@@ -69,9 +69,9 @@ class F1QH(F1):
 
         existing_files = os.listdir('/tmp')
         if existing_files:
-            versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f]
-            if versions:
-                self.version = max(versions) + 1
+            zip_versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
+            if zip_versions:
+                self.version = max(zip_versions) + 1
 
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
@@ -81,6 +81,10 @@ class F1QH(F1):
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             # Avoid to generate file if dataframe is empty
             if len(dataf):
+                if existing_files:
+                    versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
+                    if versions:
+                        self.version = max(versions) + 1
                 file_path = os.path.join('/tmp', self.filename)
                 kwargs = {'sep': ';',
                           'header': False,

--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -113,11 +113,13 @@ class F5D(F5):
         :return: file path of generated F5D File
         """
         existing_files = os.listdir('/tmp')
-        if self.default_compression != 'zip':
-            if existing_files:
+        if existing_files:
+            if self.default_compression != 'zip':
                 versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
-                if versions:
-                    self.version = max(versions) + 1
+            else:
+                versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' in f]
+            if versions:
+                self.version = max(versions) + 1
 
         file_path = os.path.join('/tmp', self.filename)
         kwargs = {'sep': ';',

--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -113,11 +113,8 @@ class F5D(F5):
         :return: file path of generated F5D File
         """
         existing_files = os.listdir('/tmp')
-        if existing_files:
-            if self.default_compression != 'zip':
-                versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
-            else:
-                versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' in f]
+        if existing_files and self.default_compression != 'zip':
+            versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
             if versions:
                 self.version = max(versions) + 1
 

--- a/mesures/mcil345.py
+++ b/mesures/mcil345.py
@@ -150,6 +150,11 @@ class MCIL345(object):
         daymin = self.file['timestamp'].min()
         daymax = self.file['timestamp'].max()
         self.measures_date = daymin
+        existing_files = os.listdir('/tmp')
+        if existing_files:
+            zip_versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
+            if zip_versions:
+                self.version = max(zip_versions) + 1
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin
@@ -158,9 +163,8 @@ class MCIL345(object):
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             # Avoid to generate file if dataframe is empty
             if len(dataf):
-                existing_files = os.listdir('/tmp')
                 if existing_files:
-                    versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f]
+                    versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
                     if versions:
                         self.version = max(versions) + 1
 

--- a/mesures/mcil345.py
+++ b/mesures/mcil345.py
@@ -155,6 +155,9 @@ class MCIL345(object):
             zip_versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
             if zip_versions:
                 self.version = max(zip_versions) + 1
+
+        zip_measures_date = self.measures_date
+        zip_version = self.version
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin
@@ -163,6 +166,7 @@ class MCIL345(object):
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             # Avoid to generate file if dataframe is empty
             if len(dataf):
+                existing_files = os.listdir('/tmp')
                 if existing_files:
                     versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
                     if versions:
@@ -182,4 +186,6 @@ class MCIL345(object):
 
             daymin = df
         zipped_file.close()
+        self.measures_date = zip_measures_date
+        self.version = zip_version
         return zipped_file.filename

--- a/mesures/mcil345qh.py
+++ b/mesures/mcil345qh.py
@@ -70,6 +70,11 @@ class MCIL345QH(MCIL345):
         daymin = self.file['timestamp'].min()
         daymax = self.file['timestamp'].max()
         self.measures_date = daymin
+        existing_files = os.listdir('/tmp')
+        if existing_files:
+            zip_versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
+            if zip_versions:
+                self.version = max(zip_versions) + 1
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin
@@ -78,9 +83,8 @@ class MCIL345QH(MCIL345):
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             # Avoid to generate file if dataframe is empty
             if len(dataf):
-                existing_files = os.listdir('/tmp')
                 if existing_files:
-                    versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f]
+                    versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
                     if versions:
                         self.version = max(versions) + 1
 

--- a/mesures/mcil345qh.py
+++ b/mesures/mcil345qh.py
@@ -75,6 +75,9 @@ class MCIL345QH(MCIL345):
             zip_versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
             if zip_versions:
                 self.version = max(zip_versions) + 1
+
+        zip_measures_date = self.measures_date
+        zip_version = self.version
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin
@@ -83,6 +86,7 @@ class MCIL345QH(MCIL345):
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             # Avoid to generate file if dataframe is empty
             if len(dataf):
+                existing_files = os.listdir('/tmp')
                 if existing_files:
                     versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
                     if versions:
@@ -102,4 +106,6 @@ class MCIL345QH(MCIL345):
 
             daymin = df
         zipped_file.close()
+        self.measures_date = zip_measures_date
+        self.version = zip_version
         return zipped_file.filename

--- a/mesures/p1.py
+++ b/mesures/p1.py
@@ -24,6 +24,7 @@ class P1(object):
         self.version = version
         self.distributor = distributor
         self.default_compression = compression
+        self.measures_date = None
 
     def __repr__(self):
         return "{}: {} kWh".format(self.filename, self.total)
@@ -146,6 +147,9 @@ class P1(object):
             zip_versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
             if zip_versions:
                 self.version = max(zip_versions) + 1
+
+        zip_measures_date = self.measures_date
+        zip_version = self.version
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin
@@ -153,6 +157,7 @@ class P1(object):
             self.measures_date = di
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             if len(dataf):
+                existing_files = os.listdir('/tmp')
                 if existing_files:
                     versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
                     if versions:
@@ -173,6 +178,8 @@ class P1(object):
 
             daymin = df
         zipped_file.close()
+        self.measures_date = zip_measures_date
+        self.version = zip_version
         new_zip_filename = os.path.join('/tmp', self.zip_filename)
         os.rename(zipped_file.filename, new_zip_filename)
         zipped_file.filename = new_zip_filename

--- a/mesures/p1.py
+++ b/mesures/p1.py
@@ -141,6 +141,11 @@ class P1(object):
         daymin = self.file['timestamp'].min()
         daymax = self.file['timestamp'].max()
         self.measures_date = daymin
+        existing_files = os.listdir('/tmp')
+        if existing_files:
+            zip_versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
+            if zip_versions:
+                self.version = max(zip_versions) + 1
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin
@@ -148,9 +153,8 @@ class P1(object):
             self.measures_date = di
             dataf = self.file[(self.file['timestamp'] >= di) & (self.file['timestamp'] < df)]
             if len(dataf):
-                existing_files = os.listdir('/tmp')
                 if existing_files:
-                    versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f]
+                    versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
                     if versions:
                         self.version = max(versions) + 1
                 # dataf['timestamp'] = dataf['timestamp'].apply(lambda x: x.strftime(DATETIME_HOUR_MASK))

--- a/mesures/p1d.py
+++ b/mesures/p1d.py
@@ -44,7 +44,7 @@ class P1D(P1):
         """
         existing_files = os.listdir('/tmp')
         if existing_files:
-            versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f]
+            versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
             if versions:
                 self.version = max(versions) + 1
 

--- a/mesures/p2.py
+++ b/mesures/p2.py
@@ -65,6 +65,14 @@ class P2(P1):
         daymin = self.file['timestamp'].min()
         daymax = self.file['timestamp'].max()
         self.measures_date = daymin
+        existing_files = os.listdir('/tmp')
+        if existing_files:
+            zip_versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
+            if zip_versions:
+                self.version = max(zip_versions) + 1
+
+        zip_measures_date = self.measures_date
+        zip_version = self.version
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin
@@ -76,7 +84,7 @@ class P2(P1):
             if len(dataf):
                 existing_files = os.listdir('/tmp')
                 if existing_files:
-                    versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
+                    versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
                     if versions:
                         self.version = max(versions) + 1
 
@@ -94,4 +102,6 @@ class P2(P1):
 
             daymin = df
         zipped_file.close()
+        self.measures_date = zip_measures_date
+        self.version = zip_version
         return zipped_file.filename

--- a/mesures/p2.py
+++ b/mesures/p2.py
@@ -76,7 +76,7 @@ class P2(P1):
             if len(dataf):
                 existing_files = os.listdir('/tmp')
                 if existing_files:
-                    versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f]
+                    versions = [int(f.split('.')[1]) for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
                     if versions:
                         self.version = max(versions) + 1
 

--- a/mesures/p2d.py
+++ b/mesures/p2d.py
@@ -46,7 +46,7 @@ class P2D(P2):
         """
         existing_files = os.listdir('/tmp')
         if existing_files:
-            versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f]
+            versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
             if versions:
                 self.version = max(versions) + 1
 

--- a/mesures/p2d.py
+++ b/mesures/p2d.py
@@ -23,7 +23,6 @@ class P2D(P2):
     def filename(self):
         filename = "{prefix}_{distributor}_{comer}_{timestamp}.{version}".format(
             prefix=self.prefix, distributor=self.distributor, comer=self.comer,
-            measures_date=self.measures_date[:10].replace('/', ''),
             timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
         )
         if self.default_compression:
@@ -35,7 +34,6 @@ class P2D(P2):
     def zip_filename(self):
         return "{prefix}_{distributor}_{comer}_{timestamp}.{version}.zip".format(
             prefix=self.prefix, distributor=self.distributor, comer=self.comer,
-            measures_date=self.measures_date[:10].replace('/', ''),
             timestamp=self.generation_date.strftime(SIMPLE_DATE_MASK),
             version=self.version
         )

--- a/mesures/p2d.py
+++ b/mesures/p2d.py
@@ -21,7 +21,7 @@ class P2D(P2):
 
     @property
     def filename(self):
-        filename = "{prefix}_{distributor}_{comer}_{measures_date}_{timestamp}.{version}".format(
+        filename = "{prefix}_{distributor}_{comer}_{timestamp}.{version}".format(
             prefix=self.prefix, distributor=self.distributor, comer=self.comer,
             measures_date=self.measures_date[:10].replace('/', ''),
             timestamp=self.generation_date.strftime('%Y%m%d'), version=self.version
@@ -33,7 +33,7 @@ class P2D(P2):
 
     @property
     def zip_filename(self):
-        return "{prefix}_{distributor}_{comer}_{measures_date}_{timestamp}.{version}.zip".format(
+        return "{prefix}_{distributor}_{comer}_{timestamp}.{version}.zip".format(
             prefix=self.prefix, distributor=self.distributor, comer=self.comer,
             measures_date=self.measures_date[:10].replace('/', ''),
             timestamp=self.generation_date.strftime(SIMPLE_DATE_MASK),

--- a/mesures/p5d.py
+++ b/mesures/p5d.py
@@ -106,7 +106,7 @@ class P5D(object):
         """
         existing_files = os.listdir('/tmp')
         if existing_files:
-            versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f]
+            versions = [int(f.split('.')[1]) for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
             if versions:
                 self.version = max(versions) + 1
 

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -1238,6 +1238,15 @@ with description('A P1D'):
         f1 = f.writer()
         assert isinstance(f1, str)
 
+    with it('Uses version control for ZIP'):
+        data = SampleData().get_sample_data()
+        f = P1D(data)
+        res = f.writer()
+        assert int(f.filename.split('.')[1]) == 1  # 2nd P1D file generated in tests
+        f = P1D(data)
+        res = f.writer()
+        assert int(f.filename.split('.')[1]) == 2  # 3rd P1D file generated in tests
+
 with description('A P2D'):
     with it('is instance of P2D Class'):
         data = SampleData().get_sample_p2d_data()

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -979,6 +979,15 @@ with description('A P5D'):
         expected = 'ES0012345678912345670F;2020/01/01 01:00;0;0;0'
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
 
+    with it('uses version control for ZIP'):
+        data = SampleData().get_sample_p5d_data()
+        f = P5D(data)
+        res = f.writer()
+        assert int(f.filename.split('.')[1]) == 2  # 3th P5D file generated in tests
+        f = P5D(data)
+        res = f.writer()
+        assert int(f.filename.split('.')[1]) == 3  # 4th P5D file generated in tests
+
 with description('An F5D'):
     with it('is instance of F5D Class'):
         data = SampleData().get_sample_f5d_data()
@@ -1024,6 +1033,15 @@ with description('An F5D'):
         expected = 'ES0012345678912345670F;2020/01/01 01:00;0;0;0;0;0;0;0;1;0;FE20214444;1000;1000'
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
 
+    with it('uses version control for ZIP'):
+        data = SampleData().get_sample_f5d_data()
+        f = F5D(data)
+        res = f.writer()
+        assert int(f.filename.split('.')[1]) == 4  # 5th F5D file generated in tests
+        f = F5D(data)
+        res = f.writer()
+        assert int(f.filename.split('.')[1]) == 5  # 6th F5D file generated in tests
+
 with description('An F1'):
     with it('is instance of F1 Class'):
         data = SampleData().get_sample_data()
@@ -1066,6 +1084,15 @@ with description('An F1'):
         expected = 'ES0012345678912345670F;11;2022/01/01 01:00:00;0;10;10;10;10;10;10;0;0;1;1'
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
 
+    with it('uses version control for ZIP'):
+        data = SampleData().get_sample_data()
+        f = F1(data)
+        res = f.writer()
+        assert int(f.zip_filename.split('.')[1]) == 5  # 6th F1 file generated in tests
+        f = F1(data)
+        res = f.writer()
+        assert int(f.zip_filename.split('.')[1]) == 6  # 7th F1 file generated in tests
+
 with description('An F1QH'):
     with it('is instance of F1QH Class'):
         data = SampleData().get_sample_f1qh_data()
@@ -1093,6 +1120,15 @@ with description('An F1QH'):
         res = f.writer()
         expected = 'ES0012345678912345670F;11;2022/01/01 00:15;0;10;10;10;10;10;10;0;0;1;1'
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
+
+    with it('Uses version control for ZIP'):
+        data = SampleData().get_sample_f1qh_data()
+        f = F1QH(data)
+        res = f.writer()
+        assert int(f.zip_filename.split('.')[1]) == 3  # 4th F1QH file generated in tests
+        f = F1QH(data)
+        res = f.writer()
+        assert int(f.zip_filename.split('.')[1]) == 4  # 5th F1QH file generated in tests
 
 
 with description('An AGRECL'):

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -1223,6 +1223,15 @@ with description('A P1'):
             assert name.endswith('.bz2')
             file_bz2 = bz2.decompress(zip_file.read(name))
 
+    with it('Uses version control for ZIP'):
+        data = SampleData().get_sample_data()
+        f = P1(data)
+        res = f.writer()
+        assert int(f.zip_filename.split('.')[1]) == 1  # 2nd P1 file generated in tests with None partner
+        f = P1(data)
+        res = f.writer()
+        assert int(f.zip_filename.split('.')[1]) == 2  # 3rd P1 file generated in tests with None partner
+
 with description('A P1D'):
     with it('is instance of P1D Class'):
         data = SampleData().get_sample_data()
@@ -1262,6 +1271,15 @@ with description('A P2D'):
         assert f.filename.endswith('.bz2')
         f1 = f.writer()
         assert isinstance(f1, str)
+
+    with it('Uses version control for ZIP'):
+        data = SampleData().get_sample_p2d_data()
+        f = P2D(data)
+        res = f.writer()
+        assert int(f.filename.split('.')[1]) == 2  # 3rd P2D file generated in tests
+        f = P2D(data)
+        res = f.writer()
+        assert int(f.filename.split('.')[1]) == 3  # 4th P2D file generated in tests
 
 with description('An A5D'):
     with it('bz2 as a default compression'):

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -1553,6 +1553,15 @@ with description('A MCIL345'):
                    'ES0291000000005555QR1F001;2022/09/01 01;1;180;0;11;22;33;44;R\n'
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False) == expected
 
+    with it('Uses version control for ZIP'):
+        data = SampleData().get_sample_mcil345_data()
+        f = MCIL345(data)
+        res = f.writer()
+        assert int(f.zip_filename.split('.')[1]) == 2  # 3rd MCIL345 file generated in tests
+        f = MCIL345(data)
+        res = f.writer()
+        assert int(f.zip_filename.split('.')[1]) == 3  # 4th MCIL345 file generated in tests
+
 with description('A MCIL345QH'):
     with it('is instance of MCIL345QH Class'):
         data = SampleData().get_sample_mcil345qh_data()
@@ -1581,6 +1590,15 @@ with description('A MCIL345QH'):
                    'ES0291000000005555QR1F001;2022/09/01 00:15;1;180;0;11;22;33;44;R\n'\
                    'ES0291000000005555QR1F001;2022/09/01 00:30;1;180;0;11;22;33;44;R\n'
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False) == expected
+
+    with it('Uses version control for ZIP'):
+        data = SampleData().get_sample_mcil345qh_data()
+        f = MCIL345QH(data)
+        res = f.writer()
+        assert int(f.zip_filename.split('.')[1]) == 2  # 3rd MCIL345QH file generated in tests
+        f = MCIL345QH(data)
+        res = f.writer()
+        assert int(f.zip_filename.split('.')[1]) == 3  # 4th MCIL345QH file generated in tests
 
 with description('A CILDAT'):
     with it('is instance of CILDAT Class'):


### PR DESCRIPTION
## Objetivos

- Mejorar el tratamiento del versionado de ficheros para que al generar ficheros ZIP, tanto el propio ZIP como los ficheros contenidos tengan un versionado correcto y robusto, evitando colisiones con ficheros generados previamente.
- Implementar nuevos tests para garantizar el correcto funcionamiento.
  - F1
  - F1QH
  - F5D
  - MCIL345
  - MCIL345QH
  - P1
  - P1D
  - P2D
  - P5D
- Extra:
    - Se ha corregido la máscara del nombre del fichero `P2D` (no debe incluir la fecha del período, a pesar de la documentación de SIMEL, sólo debe incluir la fecha de generación).
    - Se ha actualizado la plantilla de las "pull-requests".

## Comportamiento antiguo

- Si el fichero es ZIP, tanto el ZIP como los ficheros contenidos usan el mismo versionado.

## Comportamiento nuevo

- Si el fichero es ZIP, se controlan de forma independiente las versiones del ZIP y de los ficheros contenidos.

## Relacionado

- Origen de la tarea: TASK-77820

## Checklist

- [x] Test code
