### PR TITLE
Addapt AUTOCONSUMO and new tests

### DIFF
--- a/mesures/autoconsumo.py
+++ b/mesures/autoconsumo.py
@@ -16,6 +16,7 @@ class AUTOCONSUMO(object):
         :param compression: 'bz2', 'gz'... OR False otherwise
         """
         data = DummyKeys(data).data
+        self.columns = columns
         self.file = self.reader(data)
         self.generation_date = datetime.now()
         self.prefix = 'AUTOCONSUMO'
@@ -60,7 +61,7 @@ class AUTOCONSUMO(object):
     def reader(self, file_path):
         if isinstance(file_path, str):
             df = pd.read_csv(
-                file_path, sep=';', names=columns
+                file_path, sep=';', names=self.columns
             )
         elif isinstance(file_path, list):
             df = pd.DataFrame(data=file_path)
@@ -71,11 +72,10 @@ class AUTOCONSUMO(object):
             lambda x: REE_END_DATE if not isinstance(x, pd.Timestamp) else x.strftime('%Y%m%d'))
         df['data_alta'] = df['data_alta'].apply(lambda x: x.strftime('%Y%m%d'))
         df['emmagatzematge'] = np.where(df['emmagatzematge'], 'S', 'N')
-        #df['potencia_nominal'] = np.where(df['cil'], '', df['potencia_nominal'])
         df['subgrup'] = df['subgrup'].apply(lambda x: '{}.{}.{}'.format(x[0], x[1], x[2]) if x != '' else '')
         df['tipus_antiabocament'] = (
             df['tipus_antiabocament'].apply(lambda x: '' if (x == 0 or not x or x == '') else x))
-        df = df[columns]
+        df = df[self.columns]
         return df
 
     def writer(self):
@@ -85,7 +85,7 @@ class AUTOCONSUMO(object):
         file_path = os.path.join('/tmp', self.filename)
         kwargs = {'sep': ';',
                   'header': False,
-                  'columns': columns,
+                  'columns': self.columns,
                   'index': False,
                   check_line_terminator_param(): ';\n'
                   }

--- a/mesures/headers.py
+++ b/mesures/headers.py
@@ -54,7 +54,8 @@ AUTOCONSUMO_HEADER = [
     'subgrup',
     'emmagatzematge',
     'data_alta',
-    'data_baixa'
+    'data_baixa',
+    'estat'
 ]
 
 CILCAU_HEADER = [

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -1157,15 +1157,17 @@ with description('An ALMACENACAU'):
 with description('An AUTOCONSUMO'):
     with it('with compression=False must be a raw file'):
         data = [
-            {'cau': 'A', 'miteco': '1', 'reg_auto_prov': '12345', 'reg_auto_def': '1111',
-             'tipus_autoconsum': 'A', 'tipus_antiabocament': '1', 'nom': 'test', 'configuracio_mesura': '1111',
+            {'cau': 'ES0012345678912345670FA001', 'miteco': '1', 'reg_auto_prov': '12345', 'reg_auto_def': '1111',
+             'tipus_autoconsum': '41', 'tipus_antiabocament': '1', 'nom': 'test', 'configuracio_mesura': '1111',
              'potencia_nominal': '2', 'codi_postal': '17007', 'subgrup': 'b11', 'emmagatzematge': '1111',
-             'data_alta': '2021-01-12'}
+             'data_alta': '2021-01-12', 'estat': '1'}
         ]
         f = AUTOCONSUMO(data, compression=False)
         assert f.filename.endswith('.0')
         filepath = f.writer()
         assert 'bz2' not in filepath
+        expected = 'ES0012345678912345670FA001;1;12345;1111;41;1;test;1111;2;17007;b.1.1;S;20210112;30000101;1'
+        assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
 
 with description('An CUPSCAU'):
     with it('with compression=False must be a raw file'):


### PR DESCRIPTION
## Objetivos

- Añadir el campo `estado` al fichero `AUTOCONSUMO`, indicando si el CAU tiene o no contrato ATR activo.

<img width="898" height="931" alt="image" src="https://github.com/user-attachments/assets/591ac1de-7384-4c1c-b4de-52376313bca1" />

## Relacionado

- Origen de la tarea: TASK-

## Checklist

- [x] Test code
