### PR TITLE
Añadir versionado a los F5/F5D en formato ZIP

### DIFF
--- a/mesures/f5.py
+++ b/mesures/f5.py
@@ -168,9 +168,10 @@ class F5(object):
 
         existing_files = os.listdir('/tmp')
         if existing_files:
-            zip_versions = [int(f.split('.')[1])
+            zip_versions = [f.split('.')[1]
                             for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
             if zip_versions:
+                zip_versions = [int(x) for x in zip_versions if x.isdigit()]
                 self.zip_version = max(zip_versions) + 1
 
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')

--- a/mesures/f5.py
+++ b/mesures/f5.py
@@ -38,6 +38,7 @@ class F5(object):
         self.prefix = 'F5'
         self.default_compression = compression
         self.version = version
+        self.zip_version = version
         self.distributor = distributor
         self.comer = comer
 
@@ -72,10 +73,11 @@ class F5(object):
 
     @property
     def zip_filename(self):
-        return "{prefix}_{distributor}_{comer}_{measures_date}_{timestamp}.zip".format(
+        return "{prefix}_{distributor}_{comer}_{measures_date}_{timestamp}.{version}.zip".format(
             prefix=self.prefix, distributor=self.distributor, comer=self.comer,
             measures_date=self.measures_date[:10].replace('/', ''),
-            timestamp=self.generation_date.strftime(SIMPLE_DATE_MASK)
+            timestamp=self.generation_date.strftime(SIMPLE_DATE_MASK),
+            version=self.zip_version
         )
 
     @property
@@ -163,6 +165,14 @@ class F5(object):
         daymin = self.file['timestamp'].min()
         daymax = self.file['timestamp'].max()
         self.measures_date = daymin
+
+        existing_files = os.listdir('/tmp')
+        if existing_files:
+            zip_versions = [int(f.split('.')[1])
+                            for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
+            if zip_versions:
+                self.zip_version = max(zip_versions) + 1
+
         zipped_file = ZipFile(os.path.join('/tmp', self.zip_filename), 'w')
         while daymin <= daymax:
             di = daymin

--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -46,9 +46,9 @@ class F5D(F5):
 
     @property
     def zip_filename(self):
-        return "{prefix}_{distributor}_{comer}_{timestamp}.zip".format(
+        return "{prefix}_{distributor}_{comer}_{timestamp}.{version}.zip".format(
             prefix=self.prefix, distributor=self.distributor, comer=self.comer,
-            timestamp=self.generation_date.strftime(SIMPLE_DATE_MASK)
+            timestamp=self.generation_date.strftime(SIMPLE_DATE_MASK), version=self.zip_version
         )
 
     @property
@@ -128,6 +128,12 @@ class F5D(F5):
                         for f in existing_files if self.filename.split('.')[0] in f and '.zip' not in f]
             if versions:
                 self.version = max(versions) + 1
+
+        if existing_files:
+            zip_versions = [int(f.split('.')[1])
+                            for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
+            if zip_versions:
+                self.zip_version = max(zip_versions) + 1
 
         file_path = os.path.join('/tmp', self.filename)
         kwargs = {'sep': ';',

--- a/mesures/f5d.py
+++ b/mesures/f5d.py
@@ -130,9 +130,10 @@ class F5D(F5):
                 self.version = max(versions) + 1
 
         if existing_files:
-            zip_versions = [int(f.split('.')[1])
+            zip_versions = [f.split('.')[1]
                             for f in existing_files if self.zip_filename.split('.')[0] in f and '.zip' in f]
             if zip_versions:
+                zip_versions = [int(x) for x in zip_versions if x.isdigit()]
                 self.zip_version = max(zip_versions) + 1
 
         file_path = os.path.join('/tmp', self.filename)

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -1193,7 +1193,7 @@ with description('An F5D'):
         expected = 'ES0012345678912345670F;2020/01/01 01:00;0;0;0;0;0;0;0;1;0;FE20214444;1000;1000'
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
 
-    with it('uses version control for ZIP'):
+    with it('uses version control'):
         data = SampleData().get_sample_f5d_data()
         f = F5D(data)
         res = f.writer()
@@ -1201,6 +1201,15 @@ with description('An F5D'):
         f = F5D(data)
         res = f.writer()
         assert int(f.filename.split('.')[1]) == 5  # 6th F5D file generated in tests
+
+    with it('uses version control in ZIP'):
+        data = SampleData().get_sample_f5d_data()
+        f = F5D(data, compression='zip')
+        res = f.writer()
+        assert int(f.zip_filename.split('.')[1]) == 1  # 2nd F5D file with ZIP format generated in tests
+        f = F5D(data, compression='zip')
+        res = f.writer()
+        assert int(f.zip_filename.split('.')[1]) == 2  # 3rd F5D file with ZIP format generated in tests
 
 with description('An F1'):
     with it('is instance of F1 Class'):


### PR DESCRIPTION
## Objetivos

- Añadir versionado a los ficheros `F5D` y `F5` en formato ZIP.
- Implementar tests para el nuevo comportamiento.

## Relacionado

- Origen de la tarea: TASK-86582

## Checklist

- [x] Test code
