### PR TITLE
Mejoras al informar sistema de antivertido en históricos de AUTOCONSUMO

### DIFF
--- a/mesures/autoconsumo.py
+++ b/mesures/autoconsumo.py
@@ -80,8 +80,11 @@ class AUTOCONSUMO(object):
 
         df['subgrup'] = df['subgrup'].apply(lambda x: '{}.{}.{}'.format(x[0], x[1], x[2]) if x != '' else '')
 
-        df['tipus_antiabocament'] = (
-            df['tipus_antiabocament'].apply(lambda x: '' if (x == 0 or not x or x == '') else x))
+        df['tipus_antiabocament'] = df['tipus_antiabocament'].apply(lambda x: '' if (x == 0 or not x or x == '') else x)
+
+        df['tipus_antiabocament'] = np.where((df['tipus_autoconsum'].isin(['31', '32', '33']) & (df['tipus_antiabocament'].isin(['']))),
+                                             '1',
+                                             df['tipus_antiabocament'])
 
         try:
             df = df[self.columns]

--- a/spec/generation_files_spec.py
+++ b/spec/generation_files_spec.py
@@ -1327,7 +1327,7 @@ with description('An AUTOCONSUMO'):
     with it('with compression=False must be a raw file'):
         data = [
             {'cau': 'ES0012345678912345670FA001', 'miteco': '1', 'reg_auto_prov': '12345', 'reg_auto_def': '1111',
-             'tipus_autoconsum': '41', 'tipus_antiabocament': '1', 'nom': 'test', 'configuracio_mesura': '1111',
+             'tipus_autoconsum': '41', 'tipus_antiabocament': '', 'nom': 'test', 'configuracio_mesura': '1111',
              'potencia_nominal': '2', 'codi_postal': '17007', 'subgrup': 'b11', 'emmagatzematge': '1111',
              'data_alta': '2021-01-12', 'estat': '1'}
         ]
@@ -1335,7 +1335,33 @@ with description('An AUTOCONSUMO'):
         assert f.filename.endswith('.0')
         filepath = f.writer()
         assert 'bz2' not in filepath
-        expected = 'ES0012345678912345670FA001;1;12345;1111;41;1;test;1111;2;17007;b.1.1;S;20210112;30000101;1'
+        expected = 'ES0012345678912345670FA001;1;12345;1111;41;;test;1111;2;17007;b.1.1;S;20210112;30000101;1'
+        assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
+    with it("gets antiabocament value when is reported"):
+        data = [
+            {'cau': 'ES0012345678912345670FA001', 'miteco': '1', 'reg_auto_prov': '12345', 'reg_auto_def': '1111',
+             'tipus_autoconsum': '31', 'tipus_antiabocament': '2', 'nom': 'test', 'configuracio_mesura': '1111',
+             'potencia_nominal': '2', 'codi_postal': '17007', 'subgrup': 'b11', 'emmagatzematge': '1111',
+             'data_alta': '2021-01-12', 'estat': '1'}
+        ]
+        f = AUTOCONSUMO(data, compression=False)
+        assert f.filename.endswith('.0')
+        filepath = f.writer()
+        assert 'bz2' not in filepath
+        expected = 'ES0012345678912345670FA001;1;12345;1111;31;2;test;1111;2;17007;b.1.1;S;20210112;30000101;1'
+        assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
+    with it("uses '1' in antiabocament when value is not reported"):
+        data = [
+            {'cau': 'ES0012345678912345670FA001', 'miteco': '1', 'reg_auto_prov': '12345', 'reg_auto_def': '1111',
+             'tipus_autoconsum': '31', 'tipus_antiabocament': '', 'nom': 'test', 'configuracio_mesura': '1111',
+             'potencia_nominal': '2', 'codi_postal': '17007', 'subgrup': 'b11', 'emmagatzematge': '1111',
+             'data_alta': '2021-01-12', 'estat': '1'}
+        ]
+        f = AUTOCONSUMO(data, compression=False)
+        assert f.filename.endswith('.0')
+        filepath = f.writer()
+        assert 'bz2' not in filepath
+        expected = 'ES0012345678912345670FA001;1;12345;1111;31;1;test;1111;2;17007;b.1.1;S;20210112;30000101;1'
         assert f.file[f.columns].to_csv(sep=';', header=None, index=False).split('\n')[0] == expected
 
 with description('An CUPSCAU'):


### PR DESCRIPTION
## Objetivos

- Rellenar el sistema de antivertido cuando este no figura en el histórico de autoconsumo y hubo cambio de modalidad.

## Comportamiento antiguo

- El sistema antivertido se informa siempre tal como figura en el generador.

## Comportamiento nuevo

- Si el CAU no tiene excedentes y el generador no informa el sistema de antivertido, este se rellena con un '1' por defecto.

## Relacionado

- Origen de la tarea: TASK-89887

## Checklist

- [x] Test code
